### PR TITLE
Vmd, hevc, speedups, crash fixes, memory usage improvements, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ Options:
 --modes MODE LIST -    Movement modes to be investigated           
 --ecuts ECUTS LIST -   Energy cutoff values        
 --video FILE        -  Python file with PyMOL commands to be run before generating video            
---threed    -     Generates anaglyph stereo videos     
+--threed    -          Generates anaglyph stereo videos     
 --combi     -          Creates videos combining positive and negative directions for each mode/cutoff energy      
---multiple      -     Keeps multiple chains from the original PDB file (default: uses only chain A)   
+--multiple      -      Keeps multiple chains from the original PDB file (default: uses only chain A)   
+--mp4      -           Generate mp4 videos with ffmpeg (if vmd is specified, then mp4 is used regardless)
+--drawingengine   -    Whether to use vmd or pymol (defaults to pymol for now)
 
 See also the web-server-based implementation at https://pdb2movie.warwick.ac.uk.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Options:
 --threed    -          Generates anaglyph stereo videos     
 --combi     -          Creates videos combining positive and negative directions for each mode/cutoff energy      
 --multiple      -      Keeps multiple chains from the original PDB file (default: uses only chain A)   
---mp4      -           Generate mp4 videos with ffmpeg (if vmd is specified, then mp4 is used regardless)
+--mp4      -           Generate mp4 videos with ffmpeg (if vmd is specified, then mp4 is used regardless)     
 --drawingengine   -    Whether to use vmd or pymol (defaults to pymol for now)
 
 See also the web-server-based implementation at https://pdb2movie.warwick.ac.uk.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Code for generating movies of the most relevant movement modes of proteins from 
 
 Requirements:     
 PyMOL or VMD     
-Python libraries: argparse        
+Python libraries: argparse     
+ffmpeg   
 
 Instructions:      
 Recompiling FIRST and diagstd is necessary!

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ Code for generating movies of the most relevant movement modes of proteins from 
 
 
 Requirements:     
-PyMOL     
-FreeMOL mpeg_encode component     
+PyMOL or VMD     
 Python libraries: argparse        
 
 Instructions:      
@@ -12,7 +11,7 @@ Recompiling FIRST and diagstd is necessary!
 1) Go to FIRST-190916-SAW/src and run 'make'.
 2) You should be ready to go! 
 
-(Note that if your C++/Fortran compilers are not the ones I use, you might need to edit some Makefiles.)   
+(Note that if your C++/Fortran compilers are not the ones we use, you might need to edit some Makefiles.)   
 
 Usage:     
 python pdb2movie.py FILE [options]    
@@ -21,20 +20,21 @@ FILE is your desired PDB file
 Options:     
 
 --keep MOLECULE LIST - Stops the cleaning routine from removing the listed molecules from the PDB file     
---output PATH - Sets the output location for the simulations and videos    
---waters - Keeps water molecules in the PDB file (equivalent to --keep HOH)     
---confs CONFS -        Total number of configurations to be calculated     
---freq FREQ   -        Frequency of saving intermediate configurations        
---step STEP    -       Size of random step       
---dstep DSTEP    -     Size of directed step        
---res WID HEI    -     Resolution of generated videos (width, height)      
---modes MODE LIST -    Movement modes to be investigated           
---ecuts ECUTS LIST -   Energy cutoff values        
---video FILE        -  Python file with PyMOL commands to be run before generating video            
---threed    -          Generates anaglyph stereo videos     
---combi     -          Creates videos combining positive and negative directions for each mode/cutoff energy      
---multiple      -      Keeps multiple chains from the original PDB file (default: uses only chain A)   
---mp4      -           Generate mp4 videos with ffmpeg (if vmd is specified, then mp4 is used regardless)     
---drawingengine   -    Whether to use vmd or pymol (defaults to pymol for now)
+--output PATH        - Sets the output location for the simulations and videos    
+--waters             - Keeps water molecules in the PDB file (equivalent to --keep HOH)     
+--confs CONFS        - Total number of configurations to be calculated     
+--freq FREQ          - Frequency of saving intermediate configurations        
+--step STEP          - Size of random step       
+--dstep DSTEP        - Size of directed step        
+--res WID HEI        - Video resolution (width, height), range [16, 8192]     
+--modes MODE LIST    - Movement modes to be investigated           
+--ecuts ECUTS LIST   - Energy cutoff values        
+--video FILE         - Python file with PyMOL commands to be run before generating video            
+--threed             - Generates anaglyph stereo videos     
+--combi              - Creates videos combining positive and negative directions for each mode/cutoff energy      
+--multiple           - Keeps multiple chains from the original PDB file (default: uses only chain A)   
+--videocodec         - Use 'mp4' or 'hevc' to enode the videos, resulting in .mp4 or .mov files (defaults to mp4)     
+--drawingengine      - Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now) 
+--fps                - Frames per second of the videos, range [1, 240] 
 
 See also the web-server-based implementation at https://pdb2movie.warwick.ac.uk.

--- a/generate_video.py
+++ b/generate_video.py
@@ -42,7 +42,9 @@ def parsing_video_args(sys_args):
     parser.add_argument('folder', metavar='PDB', type=str, nargs=1,
                         help='Folder where the runs can be found')
     parser.add_argument('--mp4',  action='store_true',
-                        help='Generate mp4 videos with ffmpeg')
+                        help='Generate mp4 videos with ffmpeg (if vmd is specified, then mp4 is used regardless)')
+    parser.add_argument('--drawingengine', type=str, nargs=1,
+                        help='Whether to use vmd or pymol (defaults to pymol for now)')
 
     # actually do the parsing for all system args other than 0 (which is the python script name) and return the structure generated
     args = parser.parse_args(sys_args[1:])

--- a/generate_video_serial.py
+++ b/generate_video_serial.py
@@ -150,7 +150,7 @@ def gen_video(exec_folder, args, folder):
                 os.system('ln -s '+currfolder+'/tmp_RCD.pdb '+currfolder+'/tmp_froda_00000000.pdb')
 
                 #make the videos from the pdbs, using the make_video_pymol.sh or make_video_vmd.sh bash script
-                os.system('./make_video_' + args.drawingengine + '.sh ' + str(args.res[0]) + ' ' + str(args.res[1]) + ' ' + str(args.fps) + ' ' + currfolder+' '+videoname + ' ' + args.videocodec + ' ' + commandfile)
+                os.system(exec_folder + '/make_video_' + args.drawingengine + '.sh ' + str(args.res[0]) + ' ' + str(args.res[1]) + ' ' + str(args.fps) + ' ' + currfolder+' '+videoname + ' ' + args.videocodec + ' ' + commandfile)
 
     
     # now we loop over cutoffs and modes, and combine movies if --combi is specified

--- a/make_video_pymol.sh
+++ b/make_video_pymol.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+
+#check that five arguments have been given
+if [ "$#" -ne 6 ] && [ "$#" -ne 7 ]
+then
+  echo "usage: $0 video_width video_height frame_rate path_with_pdb_files destination_file_name_and_path video_codec [pymol_command_file]"
+  exit -1
+fi
+
+#arguments:
+#PDB_PATH is where to find the PDBs which must begin 'tmp_froda_'.
+#DEST_FILE is the name (and location) of the video to generate
+#OTIONAL_COMMAND_FILE is optional, and allows extra instructions to be given to pymol before generation of frames
+VIDEO_WIDTH=$1
+VIDEO_HEIGHT=$2
+FPS=$3
+PDB_PATH=$4
+DEST_FILE=$5
+VIDEO_CODEC=$6
+OTIONAL_COMMAND_FILE=$6
+
+TMP_PATH=$PDB_PATH/pymol_temp
+
+#calculate how many seconds each frame lasts, rounded to ensure ffmpeg does the right thing
+FRAME_LENGTH=$(awk -v fps=$FPS 'BEGIN { printf "%.6f", 1.0 / fps }')
+
+#make a temporary folder for the temporary files
+rm -rf $TMP_PATH
+mkdir $TMP_PATH
+
+#command file to give to pymol, to generate all necessary frames (in png format)
+CMD_FILE=$TMP_PATH/pymol.py
+
+PDB_FILES=$PDB_PATH/tmp_froda_*.pdb
+
+#array of all pdb files
+arr=(`ls $PDB_FILES`)
+
+###
+echo "make_video_pymol.sh: generating command file to give pymol - ${PDB_PATH}"
+####
+
+#setting up the pymol visuals
+echo 'from pymol import cmd' > $CMD_FILE
+echo 'import sys' >> $CMD_FILE
+
+echo "cmd.load(\"${arr[0]}\", 'original')" >> $CMD_FILE
+echo 'cmd.spectrum()' >> $CMD_FILE
+echo "cmd.viewport($VIDEO_WIDTH, $VIDEO_HEIGHT)" >> $CMD_FILE
+echo 'cmd.hide()' >> $CMD_FILE
+echo 'cmd.show("cartoon")' >> $CMD_FILE
+echo 'cmd.bg_color("grey")' >> $CMD_FILE
+
+#if an optional file with extra instructions for pymol has been included, use it
+if [ "$OPT_SETTINGS_FILE" != "" ]
+then
+  cat $OTIONAL_COMMAND_FILE >>  $CMD_FILE
+fi
+
+echo "cmd.save(\"$PDB_PATH/cartoon.pse\")" >> $CMD_FILE
+
+
+COUNTER=0
+
+for i in `ls $PDB_FILES`
+do
+  #id of the next frame (png file) to generate
+  id=$(printf "%08d" $COUNTER)
+
+  #copy the original (initial) pdb to mov
+  echo 'cmd.copy("mov", "original")' >> $CMD_FILE
+
+  #load the next pdb into mov
+  echo "cmd.load(\"$i\", 'mov')" >> $CMD_FILE
+
+  #display every currently loaded object in cartoon form
+  echo 'cmd.show("cartoon")' >> $CMD_FILE
+
+  #hide (undisplay) the original (initial) pdb
+  echo 'cmd.hide("everything", "original")' >> $CMD_FILE
+
+  #go to frame 2 of mov (the frame containing the pdb to be rendered next)
+  echo "cmd.frame(2)" >> $CMD_FILE
+
+  #render the next frame (png file)
+  echo "cmd.mpng(\"$TMP_PATH/$id\", 2, 2, 0, 0, 2, 0, $VIDEO_WIDTH, $VIDEO_HEIGHT)" >> $CMD_FILE
+
+  #remove (unload) mov (including the pdb just used)
+  echo 'cmd.delete("mov")' >> $CMD_FILE
+
+  ((COUNTER+=1))
+done
+
+echo 'cmd.quit()' >> $CMD_FILE
+
+###
+echo "make_video_pymol.sh: running pymol with generated command file to create frames (png files) - ${PDB_PATH}"
+###
+
+#run pymol without the GUI, suppressing the startup output, giving it the command file to run
+( set -x ; pymol -c -q $CMD_FILE )
+
+###
+echo "make_video_pymol.sh: generating concat file to give ffmpeg - ${PDB_PATH}"
+###
+
+#file to give to ffmpeg, stating ordering and repeating of frames (1s freezeframe, forwards, 1s freezeframe, backwards)
+CONCAT_FILE=$TMP_PATH/concat
+
+
+#hold the first png file for one second
+echo "file $TMP_PATH/000000000002.png" > $CONCAT_FILE
+echo "duration 1" >> $CONCAT_FILE
+
+#use each png file in forward order, holding each for the length of a frame
+((COUNTER-=2))
+
+for ((i=1; i<=COUNTER; i++))
+do
+
+  id=$(printf "%08d" $i)
+
+  echo "file $TMP_PATH/${id}0002.png" >> $CONCAT_FILE
+  echo "duration $FRAME_LENGTH" >> $CONCAT_FILE
+
+done
+
+#hold the last png file for one second
+echo "file $TMP_PATH/$(printf "%08d" $((COUNTER+1)))0002.png" >> $CONCAT_FILE
+echo "duration 1" >> $CONCAT_FILE
+
+#use each png file in reverse order, holding each for the length of a frame
+for ((i=COUNTER; i>=0; i--))
+do
+
+  id=$(printf "%08d" $i)
+
+  echo "file $TMP_PATH/${id}0002.png" >> $CONCAT_FILE
+  echo "duration $FRAME_LENGTH" >> $CONCAT_FILE
+
+done
+
+###
+echo "make_video_pymol.sh: running ffmpeg with generated concat file to create video from frames using $VIDEO_CODEC codec - ${PDB_PATH}"
+###
+
+#encode video from frames (png files) using ffmpeg and the specified codec
+
+if [ "$VIDEO_CODEC" == "mp4" ]
+then
+  (
+  set -x
+  
+  ffmpeg -hide_banner -loglevel warning -f concat -safe 0 -i $TMP_PATH/concat -framerate $FPS -r $FPS -c:v libx264 -pix_fmt yuv420p -crf 20 -maxrate 6M -bufsize 1M -threads 1 -movflags faststart -y ${DEST_FILE}
+  )
+fi
+
+if [ "$VIDEO_CODEC" == "hevc" ]
+then
+  (
+  set -x
+  
+  ffmpeg -hide_banner -loglevel warning -f concat -safe 0 -i $TMP_PATH/concat -framerate $FPS -r $FPS -c:v libx265 -pix_fmt yuv420p -crf 25 -maxrate 6M -bufsize 1M -threads 1 -movflags faststart -y ${DEST_FILE}
+  )
+fi
+
+
+#set the correct permissions
+chmod 744 $DEST_FILE
+
+
+#remove all the temporary files/folders made in this script, leaving only the video
+rm -rf $TMP_PATH

--- a/make_video_vmd.sh
+++ b/make_video_vmd.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+#check that five arguments have been given
+if [ "$#" -ne 5 ]
+then
+	echo "usage: $0 video_width video_height frame_rate path_with_pdb_files destination_file_name_and_path"
+	exit -1
+fi
+
+#arguments:
+#PDB_PATH is where to find the PDBs which must begin 'tmp_froda_'.
+#DEST_FILE is the name (and location) of the video to generate
+VIDEO_WIDTH=$1
+VIDEO_HEIGHT=$2
+FPS=$3
+PDB_PATH=$4
+DEST_FILE=$5
+
+TMP_PATH=$PDB_PATH/vmd_temp
+
+#calculate how many seconds each frame lasts
+FRAME_LENGTH=$(awk -v fps=$FPS 'BEGIN { print 1.0 / fps }')
+
+#make a temporary folder for the temporary files
+rm -rf $TMP_PATH
+mkdir $TMP_PATH
+
+#file to give vmd to generate all necessary frames (in tga format)
+CMD_FILE=$TMP_PATH/vmd.cmd
+
+PDB_FILES=$PDB_PATH/tmp_froda_*.pdb
+
+#function allowing vmd zooming
+echo 'proc AutoScaleAllVisible {{zoom_factor 1}} {
+  set prog 1
+  set me [lindex [info level [info level]] 0]
+  #----
+  set minX "false"
+  set minY "false"
+  set maxX "false"
+  set maxY "false"
+  set zoom [expr 1.8 * $zoom_factor]
+ 
+  #compute bb for all visible stuff
+  set mols [molinfo list]
+  foreach molid $mols {
+    if {[molinfo $molid get displayed] && [molinfo $molid get numframes] > 0} {
+      set num_reps [molinfo $molid get numreps]
+      if {$num_reps > 0} {
+     set seltext ""
+     for {set i 0} {$i<$num_reps} {incr i} {
+       if {[mol showrep $molid $i]} {
+         if {[string length $seltext] > 0} { set seltext "$seltext or " }
+         set temp [molinfo $molid get "{selection $i}"]
+         set seltext "${seltext}(${temp})"
+       }
+     }
+      }
+      if {[string length $seltext] > 0} {
+     set sel [atomselect $molid ($seltext)]
+     set mm [measure minmax $sel]
+     $sel delete
+     set minXtemp [lindex [lindex $mm 0] 0]
+     set minYtemp [lindex [lindex $mm 0] 1]
+     set maxXtemp [lindex [lindex $mm 1] 0]
+     set maxYtemp [lindex [lindex $mm 1] 1]
+     set minX [expr $minXtemp < $minX || $minX == "false" ? $minXtemp : $minX]
+     set minY [expr $minYtemp < $minY || $minY == "false" ? $minYtemp : $minY]
+     set maxX [expr $maxXtemp > $maxX || $maxX == "false" ? $maxXtemp : $maxX]
+     set maxY [expr $maxYtemp > $maxY || $maxY == "false" ? $maxYtemp : $maxY]
+      }
+    }
+  }
+  if {$minX != "false"} {#true for 1 true for all
+    set rangeX [expr $maxX - $minX]
+    set rangeY [expr $maxY - $minY]
+    set maxrange [expr max($rangeX,$rangeY)]
+    set target [expr $zoom/$maxrange]
+    set cscale [lindex [lindex [lindex [molinfo top get scale_matrix] 0] 0] 0]
+    set nscale [expr $target + (($cscale - $target) * pow(abs($prog-1.),$prog))]
+    eval "scale to $nscale"
+  } else {
+      puts "$me: nothing seems to be visible!"
+  }
+}' > $CMD_FILE
+
+#setting up the vmd visuals
+echo "axes location off" >> $CMD_FILE
+echo "color Display Background black" >> $CMD_FILE
+echo "mol modstyle 0 0 NewCartoon 0.300000 10.000000 4.100000 0" >> $CMD_FILE
+echo "mol modcolor 0 0 Fragment" >> $CMD_FILE
+echo "color scale method RGB" >> $CMD_FILE
+echo "animate goto 0" >> $CMD_FILE
+echo "AutoScaleAllVisible 0.93" >> $CMD_FILE
+
+
+COUNTER=0
+
+for i in `ls $PDB_FILES`
+do
+
+	id=$(printf "%08d" $COUNTER)
+
+	echo "animate goto $COUNTER" >> $CMD_FILE
+
+	echo "render snapshot $TMP_PATH/$id.tga" >> $CMD_FILE
+
+	((COUNTER+=1))
+done
+
+
+echo "quit" >> $CMD_FILE
+
+
+#run vmd without the GUI, giving it the command file to run
+vmd -dispdev openglpbuffer -size $VIDEO_WIDTH $VIDEO_HEIGHT -e $CMD_FILE $PDB_FILES
+
+
+#file to give to ffmpeg, stating ordering and repeating of frames (1s freezeframe, forwards, 1s freezeframe, backwards)
+CONCAT_FILE=$TMP_PATH/concat
+
+
+echo "file $TMP_PATH/00000000.tga" > $CONCAT_FILE
+echo "duration 1" >> $CONCAT_FILE
+
+
+((COUNTER-=2))
+
+for ((i=1; i<=COUNTER; i++))
+do
+
+	id=$(printf "%08d" $i)
+
+	echo "file $TMP_PATH/$id.tga" >> $CONCAT_FILE
+	echo "duration $FRAME_LENGTH" >> $CONCAT_FILE
+
+done
+
+
+echo "file $TMP_PATH/$(printf "%08d" $((COUNTER+1))).tga" >> $CONCAT_FILE
+echo "duration 1" >> $CONCAT_FILE
+
+
+for ((i=COUNTER; i>=0; i--))
+do
+
+	id=$(printf "%08d" $i)
+
+	echo "file $TMP_PATH/$id.tga" >> $CONCAT_FILE
+	echo "duration $FRAME_LENGTH" >> $CONCAT_FILE
+
+done
+
+
+#encode video from frames (tgas) using ffmpeg
+ffmpeg -f concat -safe 0 -i $TMP_PATH/concat -framerate $FPS -r $FPS -c:v libx264 -pix_fmt yuv420p -crf 20 -maxrate 6M -bufsize 1M -threads 1 -y $DEST_FILE
+
+
+#remove all the temporary files/folders made in this script, leaving only the video
+rm -rf $TMP_PATH

--- a/make_video_vmd.sh
+++ b/make_video_vmd.sh
@@ -92,13 +92,17 @@ echo 'proc AutoScaleAllVisible {{zoom_factor 1}} {
 }' > $CMD_FILE
 
 #setting up the vmd visuals
-echo "animate goto 0" >> $CMD_FILE
-echo "axes location off" >> $CMD_FILE
-echo "color Display Background black" >> $CMD_FILE
-echo "mol modstyle 0 0 NewCartoon 0.300000 10.000000 4.100000 0" >> $CMD_FILE
-echo "mol modcolor 0 0 Fragment" >> $CMD_FILE
-echo "color scale method RGB" >> $CMD_FILE
-echo "AutoScaleAllVisible 0.93" >> $CMD_FILE
+echo "
+  display shadows off
+  display ambientocclusion off
+  display dof off
+  animate goto 0
+  axes location off
+  color Display Background black
+  mol modstyle 0 0 NewCartoon 0.300000 10.000000 4.100000 0
+  mol modcolor 0 0 Fragment
+  color scale method RGB
+  AutoScaleAllVisible 0.93" >> $CMD_FILE
 
 #if an optional file with extra instructions for vmd has been included, use it
 if [ "$OPT_SETTINGS_FILE" != "" ]

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -97,12 +97,12 @@ if __name__ == "__main__":#
 
         try:
             os.mkdir(args.output[0])
-            os.chdir(args.outpur[0])
+            os.chdir(args.output[0])
         except Exception:
             userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/n]   ")
             if (userinput=="y"):
                 os.system("rm -r "+args.output[0]+"/*")
-                os.chdir(args.outpur[0])
+                os.chdir(args.output[0])
             else:
                 quit()
             pass

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -89,20 +89,24 @@ if __name__ == "__main__":#
     # if there is no relative path, the scripts are on current directory
     exec_folder=sys.argv[0].rsplit("/",1)[0]
     if (exec_folder.endswith(".py")):
-        exec_folder="."
-    # print(exec_folder)
+        exec_folder = os.getcwd()
+
+    #print(exec_folder)
 
 
     # if an output folder was defined, we need to make that directory if it doesn't exist,
     # and warn the user that the folder will be emptied if it exists
+    # and then make that the present working directory
     if (args.output):
 
         try:
             os.mkdir(args.output[0])
+            os.chdir(args.outpur[0])
         except Exception:
             userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/n]   ")
             if (userinput=="y"):
                 os.system("rm -r "+args.output[0]+"/*")
+                os.chdir(args.outpur[0])
             else:
                 quit()
             pass
@@ -112,8 +116,10 @@ if __name__ == "__main__":#
 
         try:
             os.mkdir(args.pdbfile[0][:-4])
+            os.chdir(args.pdbfile[0][:-4])
         except Exception:
             os.system("rm -r "+args.pdbfile[0][:-4]+"/*")
+            os.chdir(args.pdbfile[0][:-4])
             pass
 
     # now we will just call the functions defined in other files in sequence

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -32,8 +32,8 @@ def parsing_args(sys_args):
                         help='List of molecules to be kept')
     parser.add_argument('--output',  nargs=1,
                         help='Output directory')
-    parser.add_argument('--res',  nargs=2,
-                        help='Video resolution (width, height)')
+    parser.add_argument('--res',  nargs=2, type=int, default=[640, 480], 
+                        help='Video resolution (width, height), range [16, 8192]')
     parser.add_argument('--waters',  action='store_true',
                         help='Flag for keeping water molecules')
     parser.add_argument('--multiple',  action='store_true',
@@ -57,13 +57,15 @@ def parsing_args(sys_args):
     parser.add_argument('--ecuts',  nargs="+",
                         help='Energy cutoff values')
     parser.add_argument('--video',  nargs=1,
-                        help='Python file with PyMOL commands to be run before generating video')
+                        help='File with PyMOL or VMD commands to be run before generating video')
     parser.add_argument('pdbfile', metavar='PDB', type=str, nargs=1,
                         help='Initial PDB file')
-    parser.add_argument('--mp4',  action='store_true',
-                        help='Generate mp4 videos with ffmpeg (if vmd is specified, then mp4 is used regardless)')
-    parser.add_argument('--drawingengine', type=str,
-                        help='Whether to use vmd or pymol (defaults to pymol for now)')
+    parser.add_argument('--videocodec', type=str, default="mp4", 
+                        help="Use 'mp4' or 'hevc' to enode the videos, resulting in .mp4 or .mov files (defaults to mp4)")
+    parser.add_argument('--drawingengine', type=str, default="pymol", 
+                        help="Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now)")
+    parser.add_argument('--fps',  nargs=1, type=int, default=30,
+                        help='Frames per second of the videos, range [1, 240]')
 
     # actually do the parsing for all system args other than 0
     # (which is the python script name) and return the structure generated

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -61,7 +61,9 @@ def parsing_args(sys_args):
     parser.add_argument('pdbfile', metavar='PDB', type=str, nargs=1,
                         help='Initial PDB file')
     parser.add_argument('--mp4',  action='store_true',
-                        help='Generate mp4 videos with ffmpeg')
+                        help='Generate mp4 videos with ffmpeg (if vmd is specified, then mp4 is used regardless)')
+    parser.add_argument('--drawingengine', type=str,
+                        help='Whether to use vmd or pymol (defaults to pymol for now)')
 
     # actually do the parsing for all system args other than 0
     # (which is the python script name) and return the structure generated

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -85,14 +85,10 @@ if __name__ == "__main__":#
     #     if (userinput!="y"):
     #         quit()
 
-    # check from where the python script is being called and the relative path to it;
-    # if there is no relative path, the scripts are on current directory
-    exec_folder=sys.argv[0].rsplit("/",1)[0]
-    if (exec_folder.endswith(".py")):
-        exec_folder = os.getcwd()
+    # set exec_folder to the full path of this script
+    exec_folder=os.path.dirname(os.path.abspath(sys.argv[0]))
 
     #print(exec_folder)
-
 
     # if an output folder was defined, we need to make that directory if it doesn't exist,
     # and warn the user that the folder will be emptied if it exists

--- a/runelnemo.py
+++ b/runelnemo.py
@@ -42,10 +42,7 @@ def elnemosim(exec_folder,args,hydropdb):
 
 
     # now we have a series of shell commands to set up input files for the ElNemo tools
-    # we copy the struct file as a temporary one with the process ID to avoid any duplicates
-    os.system("cp "+struct_file+" tmp_"+str(os.getpid())+".structure")
-    # we create a local copy of the pdbmat program, since it only looks for files in its current directory
-    os.system("cp "+exec_folder+"/pdbmat "+folder+"/pdbmat")
+
 
     # now, we need to generate a pdbmat options file using an external function as well - more details there!
     print ("---------------------------------------------------------------")
@@ -53,50 +50,33 @@ def elnemosim(exec_folder,args,hydropdb):
     print ("----------------------------------------------------------------")
 
     generate_pdbmat(struct_file,folder)
-    print("calling "+folder+"/pdbmat")
+    print("calling "+exec_folder+"/pdbmat")
 
-    # finally, we run our local copy of pdbmat
+    # finally, we run pdbmat
     print ("---------------------------------------------------------------")
     print ("elnemosim: running local pdbmat()")
     print ("----------------------------------------------------------------")
 
-    os.system(folder+"/pdbmat")
-    
-    # we will need to use the same trick of a local copy with diagstd as well
-    os.system("cp "+exec_folder+"/./FIRST-190916-SAW/src/diagstd "+folder+"/diagstd")
+    os.system(exec_folder+"/pdbmat")
 
-    # now, we run the local copy of diagstd
+    # now, we run diagstd
     print ("---------------------------------------------------------------")
     print ("elnemosim: running local diagstd()")
     print ("----------------------------------------------------------------")
 
-    os.system(folder+"/diagstd")
-
-    # same trick with modesplit as well 
-    os.system("cp "+exec_folder+"/modesplit "+folder+"/modesplit")
-
-    # diagstd generates an output file (pdbmat.eigenfacs) in the folder where the script was called, not necessarily the output folder - we need to copy it there
-    os.system("mv pdbmat.eigenfacs "+folder+"/pdbmat.eigenfacs")
+    os.system(exec_folder + "/FIRST-190916-SAW/src/diagstd")
 
     # now, we run modesplit with the generated structure file, the output of diagstd and the list of modes we generated (actually, a range from lowest mode to highest mode with everything in between)
-    os.system(folder+"/modesplit "+struct_file+" "+folder+"/pdbmat.eigenfacs "+str(modelist[0])+" "+str(modelist[-1]))
-    # os.system("rm "+folder+"/modesplit")
+    os.system(exec_folder+"/modesplit "+struct_file+" "+folder+"/pdbmat.eigenfacs "+str(modelist[0])+" "+str(modelist[-1]))
 
-    # modesplit also generates outputs in the local folder, not the output one - we need to move them there
-    os.system("mv pdbmat.* mode*.in "+folder+"/")
-
-    # now we have some housekeeping to do - putting all movement modes into a "Modes" folder and removing all local copies of executables
+    # now we have some housekeeping to do - putting all movement modes into a "Modes" folder
     try:
         os.mkdir(folder+"/Modes/")
     except Exception:
         os.system("rm -r "+folder+"/Modes/*")
         pass
     os.system("mv "+folder+"/mode*.in "+folder+"/Modes/")
-    os.system("rm tmp_"+str(os.getpid())+".structure")
-    os.system("rm "+folder+"/pdbmat")
-    os.system("rm "+folder+"/diagstd")
-    os.system("rm "+folder+"/modesplit")
-    # print folder,prot
+
 
 
 '''
@@ -151,12 +131,12 @@ string folder: path to the folder where outputs are being written
 
 def generate_pdbmat(struct_file,folder):
     # print("pdbmat.dat at "+folder+"/pdbmat.dat")
-    filename='pdbmat.dat'
+    filename=folder + '/pdbmat.dat'
     # we start by creating a pdbmat.dat file and opening it
     datfile=open(filename,'w')
 
-    # the only variable in this is the name of the struct file - we should probably be getting it from the argument being passed, but we're not for some reason (??)
-    datfile.write("Coordinate FILENAME = tmp_"+str(os.getpid())+".structure\n")
+    # the only variable in this is the name of the struct file
+    datfile.write("Coordinate FILENAME = " + struct_file + "\n")
     datfile.write("INTERACtion DISTance CUTOF =     12.000\n")
     datfile.write("INTERACtion FORCE CONStant =      1.000\n")
     datfile.write("Origin of MASS values      =       CONS ! CONstant, or from COOrdinate file.\n")

--- a/runelnemo.py
+++ b/runelnemo.py
@@ -157,10 +157,13 @@ def generate_pdbmat(struct_file,folder):
 
 if __name__ == "__main__":#
     args=[]
-    hydro=sys.argv[1]
-    exec_folder=sys.argv[0].rsplit("/",1)[0]
-    if (exec_folder.endswith(".py")):
-        exec_folder="."
+    hydro=os.path.abspath(sys.argv[1])
+
+    # set exec_folder to the full path of this script
+    exec_folder=os.path.dirname(os.path.abspath(sys.argv[0]))
+
+    os.chdir(os.path.dirname(hydro))
+
     # pymol_test()
     # prepare_script(sys.argv,"t1t.mpg")
     elnemosim(exec_folder,args,hydro)

--- a/runfirst.py
+++ b/runfirst.py
@@ -44,7 +44,7 @@ def firstsim(exec_folder,args,cleanpdb):
     print ("firstsim: calling reduce.3.23.130521")
     print ("----------------------------------------------------------------")
 
-    os.system(exec_folder+"/./reduce.3.23.130521 -DB "+exec_folder+"/reduce_het_dict.txt -build "+cleanpdb+" > "+cleanpdb[:-9]+"hydro.pdb")
+    os.system(exec_folder+"/reduce.3.23.130521 -DB "+exec_folder+"/reduce_het_dict.txt -build "+cleanpdb+" > "+cleanpdb[:-9]+"hydro.pdb")
 
     # we also isolate the folder where outputs are being saved
     folder=cleanpdb.rsplit("/",1)[0]
@@ -58,14 +58,7 @@ def firstsim(exec_folder,args,cleanpdb):
     print ("firstsim: running FIRST with new PDB file after hydrogens added")
     print ("----------------------------------------------------------------")
 
-    os.system(exec_folder+"/./FIRST-190916-SAW/src/FIRST "+cleanpdb[:-9]+"hydro.pdb -non -dil 1 -E -0 -covout -hbout -phout -srout")
-
-    # housekeeping: move the output files to the output folder
-    os.system("mv "+prot+"_hydro_hbdilute.txt "+folder+"/"+prot+"_hydro_hbdilute.txt")
-    os.system("mv "+prot+"_hydro_hbdpath.txt "+folder+"/"+prot+"_hydro_hbdpath.txt")
-    os.system("mv "+prot+"_hydro_hbd_lrc.txt "+folder+"/"+prot+"_hydro_hbd_lrc.txt")
-    os.system("mv residue_map.txt "+folder+"/residue_map.txt")
-    # print("\n\n\n\n"+cleanpdb[:-9]+"hydro.pdb")
+    os.system(exec_folder+"/FIRST-190916-SAW/src/FIRST "+cleanpdb[:-9]+"hydro.pdb -non -dil 1 -E -0 -covout -hbout -phout -srout")
 
     # finally, return the hydro-added PDB path
     return cleanpdb[:-9]+"hydro.pdb"

--- a/runfroda.py
+++ b/runfroda.py
@@ -20,6 +20,27 @@ def call_froda(command):
     os.system(command)
     print '--- exiting:', name
 
+
+
+'''
+call_froda_multiple: simple wrapper for calling multiple shell commands
+
+Inputs: 
+- string list commands: list of shell commands to be run
+'''
+
+
+def call_froda_multiple(commands):
+    name = multiprocessing.current_process().name
+    print '--- starting thread:', name
+
+    for command in commands:
+        print '--- starting command:', command
+        os.system(command)
+        print '--- finished command:', command
+
+    print '--- exiting thread:', name
+
 '''
 frodasim: main function for running FRODA simulations on a protein
 
@@ -42,7 +63,7 @@ def frodasim(exec_folder,args,hydro_file):
     folder=hydro_file.rsplit("/",1)[0]
 
     # now we need to care about a bunch of command-line arguments: if they were passed, we set them, otherwise we use default values
-    # that is true for confs, frew, step, dstep, modes, ecuts
+    # that is true for confs, freq, step, dstep, modes, ecuts
     if args.confs:
         totconf=int(args.confs[0])
     else:
@@ -96,6 +117,21 @@ def frodasim(exec_folder,args,hydro_file):
     print ("runfroda: generating subfolders")
     print ("----------------------------------------------------------------")
 
+    #count the number of cores; this is the number of threads we will run
+    number_of_cores = multiprocessing.cpu_count()
+
+    #this counts up for every command that must be run
+    counter = 0
+
+    #create a list of lists of commands, so that each list is given to a different thread to run
+    commands = [[]]
+
+    #we want to have a list for each thread
+    for i in range (0, number_of_cores - 1):
+        commands.append([])
+
+    #print(number_of_cores)
+
     # now for every cutoff energy we will create a subfolder before anything
     for cut in cutlist:
         try:
@@ -135,10 +171,19 @@ def frodasim(exec_folder,args,hydro_file):
                 else:
                     command=exec_folder+"/./FIRST-190916-SAW/src/FIRST "+folder+"/Runs/"+str(cut)+"/Mode"+mode+"-"+sign+"/tmp.pdb"+" -non -E -"+str(cut)+" -FRODA -mobRC1 -freq "+str(freq)+" -totconf "+str(totconf)+" -modei -step "+str(step)+" -dstep "+str(dstep)+" -covin -hbin -phin -srin"
 
-                # we assign a new process to this call of froda (the reason why call_froda exists at all), append it to job list and start it
-                p = multiprocessing.Process(name=command,target=call_froda,args=(command,))
-                jobs.append(p)
-                p.start()
+                #add each command to one of the lists of commands, rotating which one each time
+                commands[counter % number_of_cores].append(command)
+                counter += 1
+
+
+    #print(commands)
+
+    #start a thread for each core, giving it a list of commands
+    for i in range (0, number_of_cores):
+        p = multiprocessing.Process(name="thread" + str(i),target=call_froda_multiple,args=(commands[i],))
+        jobs.append(p)
+        p.start()
+
 
     # this is here so that we wait for all processes to finish before proceeding
     for job in jobs:

--- a/runfroda.py
+++ b/runfroda.py
@@ -51,7 +51,7 @@ def frodasim(exec_folder,args,hydro_file):
     if args.freq:
         freq=int(args.freq[0])
     else:
-        freq=100
+        freq=50
 
     if args.step:
         step=float(args.step[0])


### PR DESCRIPTION
Added arguments:
--videocodec  - Use 'mp4' or 'hevc' to enode the videos, resulting in .mp4 or .mov files (defaults to mp4)     
--drawingengine - Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now) 
--fps - Frames per second of the videos, range [1, 240]  (defaults to 30 - was implemented as 15 before) 
--freq now defaults to 50 (to account for the higher framerate - was 100)

Crash fixes:
-shared areas are not used to store temporary files, preventing crashes when running in parallel
-froda only uses as many threads as there are cpu cores, avoiding extremely high total memory usage (and resulting crashes)
-pymol does not load all pdb files at once, reducing memory usage (and resulting crashes)

Performance improvements:
-pymol approx 4x faster due to reusing of identical frames
-vmd runs hundreds of times faster than that
-other minor changes

Dependencies:
-freemol removed (never needed now)
-ffmpeg now always needed

See individual commits for more detail and other misc changes
