### PR TITLE
fix bug when running on pdb file with long path (the bug found when running on SCRTP machines)

### DIFF
--- a/runelnemo.py
+++ b/runelnemo.py
@@ -136,7 +136,7 @@ def generate_pdbmat(struct_file,folder):
     datfile=open(filename,'w')
 
     # the only variable in this is the name of the struct file
-    datfile.write("Coordinate FILENAME = " + struct_file + "\n")
+    datfile.write("Coordinate FILENAME = " + os.path.basename(struct_file) + "\n")
     datfile.write("INTERACtion DISTance CUTOF =     12.000\n")
     datfile.write("INTERACtion FORCE CONStant =      1.000\n")
     datfile.write("Origin of MASS values      =       CONS ! CONstant, or from COOrdinate file.\n")


### PR DESCRIPTION
-pdbmat cannot accept path/filenames over 52 characters, so give it the filename instead of the full path