### PR TITLE
First implementation of automatic reuse of previous results, and other assorted improvements

### DIFF
--- a/FIRST-190916-SAW/src/Makefile
+++ b/FIRST-190916-SAW/src/Makefile
@@ -47,7 +47,7 @@ FORT = gfortran
 CPP = g++
 CPP_OPTIMIZATION = -O3
 #DEBUG = -g -pg
-EXTRA = -Wall
+#EXTRA = -Wall
 CPPFLAGS = $(INC) ${CPP_OPTIMIZATION} $(DEBUG) ${EXTRA} -ansi -fPIC
 
 INSTALL_HOME = $(CURDIR)/..

--- a/README.md
+++ b/README.md
@@ -19,23 +19,24 @@ Recompiling FIRST and diagstd is necessary!
 
 ## Options:     
 
+--output PATH          - Set the output location for the videos, defaulting to `FILE` without the `.pdb`    
+--overwrite            - Delete the contents of the output folder before beginning
+--forceoverwrite       - Overwrite and silence all are-you-sure messages    
 --keep MOLECULE LIST   - Stops the cleaning routine from removing the listed molecules from the PDB file     
---output PATH          - Sets the output location for the simulations and videos    
 --waters               - Keeps water molecules in the PDB file (equivalent to --keep HOH)     
+--multiple             - Keeps multiple chains from the original PDB file (default: uses only chain A)   
 --confs CONFS          - Total number of configurations to be calculated     
 --freq FREQ            - Frequency of saving intermediate configurations        
 --step STEP            - Size of random step       
 --dstep DSTEP          - Size of directed step        
---res WID HEI          - Video resolution (width, height), range [16, 8192]     
 --modes MODE LIST      - Movement modes to be investigated           
 --ecuts ECUTS LIST     - Energy cutoff values        
 --video FILE           - Python file with PyMOL commands to be run before generating video            
---nomovie              - Do not generate any videos            
---threed               - Generates anaglyph stereo videos     
 --combi                - Creates videos combining positive and negative directions for each mode/cutoff energy      
---multiple             - Keeps multiple chains from the original PDB file (default: uses only chain A)   
---videocodec CODEC     - Use 'mp4' or 'hevc' to enode the videos, resulting in .mp4 or .mov files (default: mp4)     
+--nomovie              - Do not generate any videos            
+--res WID HEI          - Video resolution (width, height), range [16, 8192]     
 --drawingengine ENGINE - Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now)     
---fps                  - Frames per second of the videos, range [1, 240] 
+--fps                  - Frames per second of the videos, range [1, 240]    
+--videocodec CODEC     - Use 'mp4' or 'hevc' to enode the videos, resulting in .mp4 or .mov files (default: mp4)     
 
 See also the web-server-based implementation at https://pdb2movie.warwick.ac.uk.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ FILE is your desired PDB file
 --combi              - Creates videos combining positive and negative directions for each mode/cutoff energy      
 --multiple           - Keeps multiple chains from the original PDB file (default: uses only chain A)   
 --videocodec         - Use 'mp4' or 'hevc' to enode the videos, resulting in .mp4 or .mov files (defaults to mp4)     
---drawingengine      - Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now)
+--drawingengine      - Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now)     
 --fps                - Frames per second of the videos, range [1, 240] 
 
 See also the web-server-based implementation at https://pdb2movie.warwick.ac.uk.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Recompiling FIRST and diagstd is necessary!
 --modes MODE LIST      - Movement modes to be investigated           
 --ecuts ECUTS LIST     - Energy cutoff values        
 --video FILE           - Python file with PyMOL commands to be run before generating video            
+--nomovie              - Do not generate any videos            
 --threed               - Generates anaglyph stereo videos     
 --combi                - Creates videos combining positive and negative directions for each mode/cutoff energy      
 --multiple             - Keeps multiple chains from the original PDB file (default: uses only chain A)   

--- a/README.md
+++ b/README.md
@@ -8,33 +8,33 @@ ffmpeg
 
 ## Instructions:      
 Recompiling FIRST and diagstd is necessary!
-1) Go to FIRST-190916-SAW/src and run 'make'.
+1) Go to FIRST-190916-SAW/src and run `make`.
 2) You should be ready to go! 
 
 (Note that if your C++/Fortran compilers are not the ones we use, you might need to edit some Makefiles.)   
 
 ## Usage:     
-python pdb2movie.py FILE [options]    
-FILE is your desired PDB file    
+`python pdb2movie.py FILE [options]`    
+`FILE` is the PBD file of the protein for which you want to generate videos.    
 
 ## Options:     
 
---keep MOLECULE LIST - Stops the cleaning routine from removing the listed molecules from the PDB file     
---output PATH        - Sets the output location for the simulations and videos    
---waters             - Keeps water molecules in the PDB file (equivalent to --keep HOH)     
---confs CONFS        - Total number of configurations to be calculated     
---freq FREQ          - Frequency of saving intermediate configurations        
---step STEP          - Size of random step       
---dstep DSTEP        - Size of directed step        
---res WID HEI        - Video resolution (width, height), range [16, 8192]     
---modes MODE LIST    - Movement modes to be investigated           
---ecuts ECUTS LIST   - Energy cutoff values        
---video FILE         - Python file with PyMOL commands to be run before generating video            
---threed             - Generates anaglyph stereo videos     
---combi              - Creates videos combining positive and negative directions for each mode/cutoff energy      
---multiple           - Keeps multiple chains from the original PDB file (default: uses only chain A)   
---videocodec         - Use 'mp4' or 'hevc' to enode the videos, resulting in .mp4 or .mov files (defaults to mp4)     
---drawingengine      - Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now)     
---fps                - Frames per second of the videos, range [1, 240] 
+--keep MOLECULE LIST   - Stops the cleaning routine from removing the listed molecules from the PDB file     
+--output PATH          - Sets the output location for the simulations and videos    
+--waters               - Keeps water molecules in the PDB file (equivalent to --keep HOH)     
+--confs CONFS          - Total number of configurations to be calculated     
+--freq FREQ            - Frequency of saving intermediate configurations        
+--step STEP            - Size of random step       
+--dstep DSTEP          - Size of directed step        
+--res WID HEI          - Video resolution (width, height), range [16, 8192]     
+--modes MODE LIST      - Movement modes to be investigated           
+--ecuts ECUTS LIST     - Energy cutoff values        
+--video FILE           - Python file with PyMOL commands to be run before generating video            
+--threed               - Generates anaglyph stereo videos     
+--combi                - Creates videos combining positive and negative directions for each mode/cutoff energy      
+--multiple             - Keeps multiple chains from the original PDB file (default: uses only chain A)   
+--videocodec CODEC     - Use 'mp4' or 'hevc' to enode the videos, resulting in .mp4 or .mov files (default: mp4)     
+--drawingengine ENGINE - Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now)     
+--fps                  - Frames per second of the videos, range [1, 240] 
 
 See also the web-server-based implementation at https://pdb2movie.warwick.ac.uk.

--- a/cleanpdb.py
+++ b/cleanpdb.py
@@ -63,7 +63,6 @@ def cleanPDB(args):
         return output_filename
 
     # open a file to write to
-    os.system("rm -f " + output_filename + "_incomplete")
     output=open(output_filename + "_incomplete",'w')
 
     # initialise a list of residues

--- a/cleanpdb.py
+++ b/cleanpdb.py
@@ -98,21 +98,15 @@ def cleanPDB(args,exec_folder):
     # opens the input file received as one of the arguments for reading
     inputfile=open(args.pdbfile[0],'r')
 
-
     # initialise a list of residues
     residues=[]
 
+    print(args.output[0])
+
     # set output filename based on arguments received and open that file for writing
-    if (args.output):
-        output_filename=args.output[0]+"/"+args.pdbfile[0].rsplit("/",1)[1][:-4]+"_clean.pdb"
-
-    else:
-        folder=args.pdbfile[0].split("/")
-        output_filename=args.pdbfile[0][:-4]+"/"+folder[-1][:-4]+"_clean.pdb"
-    #print(output_filename)
+    output_filename=args.output[0]+"/"+args.pdbfile[0].rsplit("/",1)[1][:-4]+"_clean.pdb"
+    print(output_filename)
     output=open(output_filename,'w')
-
-
 
     # goes over every single line from tge 
     for line in inputfile:

--- a/cleanpdb.py
+++ b/cleanpdb.py
@@ -8,12 +8,13 @@ cleanpdb.py - removes rotamers and non-protein molecules
 
 import sys
 import os
-
-import helpers
 try:
     from exceptions import RuntimeError
 except ImportError:
     from builtins import RuntimeError
+
+import helpers
+
 
 '''
 remove_rotamers: uses pymol to keep a single rotamer from the pdb file
@@ -24,10 +25,12 @@ string exec_folder: location where the python scripts are located
 
 Outputs:
 structure args: structured object with fields corresponding to the possible parameters from command line
+
 '''
 def remove_rotamers(output_filename,exec_folder):
     # calls pymol using remove_rotamers.py - for details on this, see that file!
     os.system('pymol -qc '+exec_folder+'/remove_rotamers.py '+output_filename)
+
 
 
 '''
@@ -123,7 +126,8 @@ def cleanPDB(args):
     return output_filename
 
 
-# calling this script by itself works as if it were pdb2movie works but is inadvisable
+
+# calling this script by itself works as if it were pdb2movie but is inadvisable
 
 if __name__ == "__main__":
     # parse commmand-line arguments

--- a/cleanpdb.py
+++ b/cleanpdb.py
@@ -8,8 +8,8 @@ cleanpdb.py - removes rotamers and non-protein molecules
 
 import sys
 import os
-import argparse
-import pdb2movie
+
+import helpers
 try:
     from exceptions import RuntimeError
 except ImportError:
@@ -28,54 +28,6 @@ structure args: structured object with fields corresponding to the possible para
 def remove_rotamers(output_filename,exec_folder):
     # calls pymol using remove_rotamers.py - for details on this, see that file!
     os.system('pymol -qc '+exec_folder+'/remove_rotamers.py '+output_filename)
-
-
-def parsing_args(sys_args):
-
-    # the argparse library takes care of all the parsing from a list of command-line arguments to a structure
-    parser = argparse.ArgumentParser(description='Runs simulations and generates videos for the most likely movement modes given a PDB file.',usage='%(prog)s PDB [options]')
-
-    parser.add_argument('--keep',  nargs="+",
-                        help='List of molecules to be kept')
-    parser.add_argument('--output',  nargs=1,
-                        help='Output directory')
-    parser.add_argument('--res',  nargs=2,
-                        help='Video resolution (width, height)')
-    parser.add_argument('--waters',  action='store_true',
-                        help='Flag for keeping water molecules')
-    parser.add_argument('--multiple',  action='store_true',
-                        help='Keep multiple chains (default: uses only chain A)')
-    parser.add_argument('--combi',  action='store_true',
-                        help='Combine both positive and negative directions into a single movie')
-    parser.add_argument('--threed',  action='store_true',
-                        help='Flag for generating anaglyph stereo movies')
-    parser.add_argument('--confs',  nargs=1,
-                        help='Total number of configurations to be calculated')
-    parser.add_argument('--freq',  nargs=1,
-                        help='Frequency of saving intermediate configurations')
-    parser.add_argument('--step',  nargs=1,
-                        help='Size of random step')
-    parser.add_argument('--dstep',  nargs=1,
-                        help='Size of directed step')
-    parser.add_argument('--modes',  nargs="+",
-                        help='Movement modes to be investigated')
-    parser.add_argument('--ecuts',  nargs="+",
-                        help='Energy cutoff values')
-    parser.add_argument('--video',  nargs=1,
-                        help='Python file with PyMOL commands to be run before generating video')
-    parser.add_argument('pdbfile', metavar='PDB', type=str, nargs=1,
-                        help='Initial PDB file')
-
-    # actually do the parsing for all system args other than 0 (which is the python script name) and return the structure generated
-    args = parser.parse_args(sys_args[1:])
-
-    #ensure pdbfile and output are full paths, not relative ones (so they are correct from here on, regardless of pwd)
-    args.pdbfile[0] = os.path.abspath(args.pdbfile[0])
-    if (args.output):
-        args.output[0] = os.path.abspath(args.output[0])
-    
-    return args
-
 
 
 '''
@@ -172,13 +124,13 @@ def cleanPDB(args):
 #calling this as a single script will probably not work, I think?
 if __name__ == "__main__":
     # parse commmand-line arguments
-    args=parsing_args(sys.argv)
+    args=helpers.parsing_args(sys.argv)
 
     # set the output folder if not specified
     if (not args.output):
         args.output = [args.pdbfile[0][:-4]]
 
-    # organise the output folder
-    pdb2movie.go_to_output_folder(args)
+    # change directory to the output folder
+    helpers.go_to_output_folder(args)
 
     cleanPDB(args)

--- a/cleanpdb.py
+++ b/cleanpdb.py
@@ -59,13 +59,20 @@ def cleanPDB(args):
         os.system("mkdir -p " + '_'.join(args.keep))
         os.chdir('_'.join(args.keep))
 
+    # set output filename based on arguments received
+    output_filename="./"+args.pdbfile[0].rsplit("/",1)[1][:-4]+"_clean.pdb"
+
+    # if the cleaned file is already here we don't need to do anything
+    if (os.path.isfile(output_filename)):
+        print("clean file already generated: " + os.path.basename(output_filename))
+        return output_filename
+
+    # open a file to write to
+    os.system("rm -f " + output_filename + "_incomplete")
+    output=open(output_filename + "_incomplete",'w')
+
     # initialise a list of residues
     residues=[]
-
-    # set output filename based on arguments received and open that file for writing
-    output_filename="./"+args.pdbfile[0].rsplit("/",1)[1][:-4]+"_clean.pdb"
-    print(output_filename)
-    output=open(output_filename,'w')
 
     # goes over every single line from tge 
     for line in inputfile:
@@ -113,6 +120,9 @@ def cleanPDB(args):
     # close files
     inputfile.close()
     output.close()
+
+    # rename file to indicate it is complete
+    os.system("mv " + output_filename + "_incomplete " + output_filename)
 
     # calls pymol to remove remaining rotamers
     #remove_rotamers(output_filename,exec_folder)

--- a/cleanpdb.py
+++ b/cleanpdb.py
@@ -63,12 +63,8 @@ def parsing_args(sys_args):
 
     # actually do the parsing for all system args other than 0 (which is the python script name) and return the structure generated
     args = parser.parse_args(sys_args[1:])
-
-    #ensure pdbfile has the full path
-    args.pdbfile[0] = os.path.abspath(args.pdbfile[0])
     
     return args
-
 
 
 

--- a/cleanpdb.py
+++ b/cleanpdb.py
@@ -59,7 +59,7 @@ def cleanPDB(args):
 
     # if the cleaned file is already here we don't need to do anything
     if (os.path.isfile(output_filename)):
-        print("clean file already generated: " + os.path.basename(output_filename))
+        print("   clean file already generated: " + os.path.basename(output_filename))
         return output_filename
 
     # open a file to write to

--- a/cleanpdb.py
+++ b/cleanpdb.py
@@ -45,19 +45,11 @@ def cleanPDB(args):
     # opens the input file received as one of the arguments for reading
     inputfile=open(args.pdbfile[0],'r')
 
-    # set args.keep as a list of molecules that need to be kept, based on the arguments received
-    # if there are any to keep, make/move to a folder for them, named after them in alphabetical order
-    if (args.keep==None):
-        args.keep=[]
-    if args.waters:
-        args.keep.append('HOH')
+    # print which molecules are being protected from being removed by cleanPDB
     if (args.keep!=[]):
         print("Keeping the following molecules: ")
         for i in args.keep:
             print(i)
-        args.keep.sort()
-        os.system("mkdir -p " + '_'.join(args.keep))
-        os.chdir('_'.join(args.keep))
 
     # set output filename based on arguments received
     output_filename="./"+args.pdbfile[0].rsplit("/",1)[1][:-4]+"_clean.pdb"
@@ -131,7 +123,8 @@ def cleanPDB(args):
     return output_filename
 
 
-#calling this as a single script will probably not work, I think?
+# calling this script by itself works as if it were pdb2movie works but is inadvisable
+
 if __name__ == "__main__":
     # parse commmand-line arguments
     args=helpers.parsing_args(sys.argv)

--- a/cleanpdb.py
+++ b/cleanpdb.py
@@ -9,7 +9,10 @@ cleanpdb.py - removes rotamers and non-protein molecules
 import sys
 import os
 import argparse
-from exceptions import RuntimeError
+try:
+    from exceptions import RuntimeError
+except ImportError:
+    from builtins import RuntimeError
 
 '''
 remove_rotamers: uses pymol to keep a single rotamer from the pdb file
@@ -148,11 +151,11 @@ def cleanPDB(args,exec_folder):
 
     # check whether there are missing residues by comparing the list with a range
     try:
-		for i in range(residues[0],residues[-1]):
-			if (not(i in residues)):
-				print("WARNING: residue "+str(i)+" is missing!")
+	    for i in range(residues[0],residues[-1]):
+	        if (not(i in residues)):
+	            print("WARNING: residue "+str(i)+" is missing!")
     except:
-		raise RuntimeError("cleanpdb: chain A seems to be empty/non-existent! --- aborting")
+	    raise RuntimeError("cleanpdb: chain A seems to be empty/non-existent! --- aborting")
 
     # close files
     inputfile.close()

--- a/generate_video.py
+++ b/generate_video.py
@@ -1,3 +1,4 @@
+###THIS FILE IS DEPRECATED. USE generate_video_serial.py INSTEAD###
 '''
 generate_video.py - takes a series of PDB files and generates a video
 

--- a/generate_video_serial.py
+++ b/generate_video_serial.py
@@ -141,9 +141,10 @@ def gen_video(exec_folder, args):
 
     # set commandfilelist to inputted paths, including none by default
     if args.video:
-        commandfilelist = [x for x in args.video]
+        commandfilelist = [(os.path.dirname(x) + "/view-" + os.path.basename(x))  for x in args.video]
     else:
         commandfilelist = [""]
+    print(commandfilelist)
 
     # ensure the videocodec input is an allowed option
     if args.videocodec != "mp4" and args.videocodec != "hevc":
@@ -158,6 +159,7 @@ def gen_video(exec_folder, args):
     # set present working directory
     folder = os.getcwd()
 
+
     print ("---------------------------------------------------------------")
     print ("gen_video: converting from pdb files to videos")
     print ("----------------------------------------------------------------")
@@ -165,23 +167,33 @@ def gen_video(exec_folder, args):
     # loop over all the command files we want to apply to the videos
     for commandfile in commandfilelist:
 
+
+        # extract name of the file from its location
+        if (commandfile == ""):
+            commandfilebase = ""
+        else:
+            commandfilebase = "/" + os.path.basename(commandfile)
+            
+            # folder for the videos with this commandfile
+            try:
+                os.mkdir(commandfilebase[1:])
+            except:
+                pass
+
+        # directory for all videos with this commandfile
+        dir = "/Runs"
+        if (step != 0.1):
+            dir += "_step" + str(step)
+        if (dstep != 0.01):
+            dir += "_dstep" + str(dstep)
+        os.system("mkdir -p " + commandfilebase[1:] + dir)
+
         # for all combinations of cutoffs and modes
         for cut in cutlist:
             for mode in modelist:
 
-                # extract name of the file from its location
-                if (commandfile == ""):
-                    commandfilebase = ""
-                else:
-                    commandfilebase = "/" + os.path.basename(commandfile)
-                    
-                    # folder for the videos with this commandfile
-                    try:
-                        os.mkdir(commandfilebase[1:])
-                    except:
-                        pass
 
-                filenamestart = folder + commandfilebase + "/Runs_step" + str(step) + "_dstep" + str(dstep) + "/" + str(cut) + "-mode" + mode + "-"
+                filenamestart = folder + commandfilebase + dir + "/" + str(cut) + "-mode" + mode + "-"
 
                 # for both directions (neg and pos)
                 for sign in signals:
@@ -191,7 +203,7 @@ def gen_video(exec_folder, args):
                     temp_videoname =  filenamestart + sign + "-" + str(args.fps) + "fps_temp" + fileextension
 
                     # this is where the relevant pdbs are located
-                    pdbfolder = folder + "/Runs_step" + str(step) + "_dstep" + str(dstep) + "/" + str(cut) + "/Mode" + mode + "-" + sign
+                    pdbfolder = folder + dir + "/" + str(cut) + "/Mode" + mode + "-" + sign
 
                     # determine whether we need to generate a video
                     if (os.path.isfile(videoname) and not os.path.isfile(videoname + "_in_progress")):
@@ -231,7 +243,7 @@ def gen_video(exec_folder, args):
                     filenameend  = "-" + str(args.fps) + "fps" + fileextension
                     videoname = filenamestart + 'combi' + filenameend
                     temp_videoname = filenamestart + 'combi' + "-" + str(args.fps) + "fps_temp" + fileextension
-                    videolist = folder + commandfilebase + "/Runs_step" + str(step) + "_dstep" + str(dstep) + "/" + str(cut) + "-mode" + mode + "-list" 
+                    videolist = folder + commandfilebase + dir + "/" + str(cut) + "-mode" + mode + "-list" 
 
                     # determine whether we need to generate a video
                     if (os.path.isfile(videoname) and not os.path.isfile(videolist)):

--- a/generate_video_serial.py
+++ b/generate_video_serial.py
@@ -125,7 +125,9 @@ def gen_video(exec_folder, args):
         freq=50
 
     # ensure the width and height inputs are within allowed ranges
-    if (args.res[0] < 16 or args.res[0] > 8192) or (args.res[1] < 16 or args.res[1] > 8192):
+    width = args.res[0]
+    height = args.res[0]
+    if (width < 16 or width > 8192) or (height < 16 or height > 8192):
         print("width or heigth out of range [16, 8192]")
         return
 
@@ -135,7 +137,8 @@ def gen_video(exec_folder, args):
         return
 
     # ensure the drawingengine input is an allowed option
-    if args.drawingengine != "pymol" and args.drawingengine != "vmd":
+    engine = args.drawingengine
+    if engine != "pymol" and engine != "vmd":
         print("drawingengine invalid")
         return
 
@@ -144,7 +147,6 @@ def gen_video(exec_folder, args):
         commandfilelist = [(os.path.dirname(x) + "/view-" + os.path.basename(x))  for x in args.video]
     else:
         commandfilelist = [""]
-    print(commandfilelist)
 
     # ensure the videocodec input is an allowed option
     if args.videocodec != "mp4" and args.videocodec != "hevc":
@@ -182,16 +184,17 @@ def gen_video(exec_folder, args):
 
         # directory for all videos with this commandfile
         dir = "/Runs"
+        if (not args.multiple):
+            dir += "_single-chain"
         if (step != 0.1):
             dir += "_step" + str(step)
         if (dstep != 0.01):
             dir += "_dstep" + str(dstep)
-        os.system("mkdir -p " + commandfilebase[1:] + dir)
+        os.system("mkdir -p " + (commandfilebase + dir)[1:])
 
         # for all combinations of cutoffs and modes
         for cut in cutlist:
             for mode in modelist:
-
 
                 filenamestart = folder + commandfilebase + dir + "/" + str(cut) + "-mode" + mode + "-"
 
@@ -199,8 +202,9 @@ def gen_video(exec_folder, args):
                 for sign in signals:
 
                     # this is where the video will be put and what it will be called
-                    videoname =  filenamestart + sign + "-" + str(args.fps) + "fps" + fileextension
-                    temp_videoname =  filenamestart + sign + "-" + str(args.fps) + "fps_temp" + fileextension
+                    filenameend  = "-" + str(confs) + "@" + str(freq) + "-" + engine + '-' + str(args.fps) + "fps-" + str(width) + "x" + str(height) + fileextension
+                    videoname =  filenamestart + sign + filenameend
+                    temp_videoname =  filenamestart + sign + "-" + str(confs) + "@" + str(freq) + "-" + engine + '-' + str(args.fps) + "fps-" + str(width) + "x" + str(height) + "_temp" + fileextension
 
                     # this is where the relevant pdbs are located
                     pdbfolder = folder + dir + "/" + str(cut) + "/Mode" + mode + "-" + sign
@@ -224,11 +228,11 @@ def gen_video(exec_folder, args):
 
                     # now we make the videos from the pdbs, using the make_video_pymol.sh or make_video_vmd.sh bash script
                     print('gen_video: ' + exec_folder + '/make_video_' + 
-                        args.drawingengine + '.sh ' + str(args.res[0]) + ' ' + str(args.res[1]) + ' ' + 
+                        engine + '.sh ' + str(width) + ' ' + str(height) + ' ' + 
                         str(args.fps) + ' ' + pdbfolder + ' ' + temp_videoname + ' ' + args.videocodec + ' ' + 
                         commandfile + ' ' + str(confs) + ' ' + str(freq))
                     os.system(exec_folder + '/make_video_' + 
-                        args.drawingengine + '.sh ' + str(args.res[0]) + ' ' + str(args.res[1]) + ' ' + 
+                        engine + '.sh ' + str(width) + ' ' + str(height) + ' ' + 
                         str(args.fps) + ' ' + pdbfolder + ' ' + temp_videoname + ' ' + args.videocodec + ' ' + 
                         commandfile + ' ' + str(confs) + ' ' + str(freq))
                     
@@ -240,9 +244,8 @@ def gen_video(exec_folder, args):
                 # combine the pos and neg videos if desired
                 if args.combi:
 
-                    filenameend  = "-" + str(args.fps) + "fps" + fileextension
                     videoname = filenamestart + 'combi' + filenameend
-                    temp_videoname = filenamestart + 'combi' + "-" + str(args.fps) + "fps_temp" + fileextension
+                    temp_videoname = filenamestart + 'combi' + "-" + str(confs) + "@" + str(freq) + "-" + engine + '-' + str(args.fps) + "fps-" + str(width) + "x" + str(height) + "_temp" + fileextension
                     videolist = folder + commandfilebase + dir + "/" + str(cut) + "-mode" + mode + "-list" 
 
                     # determine whether we need to generate a video

--- a/generate_video_serial.py
+++ b/generate_video_serial.py
@@ -46,11 +46,11 @@ def parsing_video_args(sys_args):
                         help="Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now)")
     parser.add_argument('folder', metavar='folder', type=str, nargs=1,
                         help='folder')
-    parser.add_argument('--fps',  nargs=1, type=int, default=30,
+    parser.add_argument('--fps', nargs=1, type=int, default=30,
                         help='Frames per second of the videos, range [1, 240]')
-    parser.add_argument('--confs',  nargs=1,
+    parser.add_argument('--confs', nargs=1, type=int,
                         help='Number of conformers go up to')
-    parser.add_argument('--freq',  nargs=1,
+    parser.add_argument('--freq', nargs=1, type=int,
                         help='Frequency of intermediate conformers to use')
 
     # actually do the parsing for all system args other than 0 (which is the python script name) and return the structure generated

--- a/generate_video_serial.py
+++ b/generate_video_serial.py
@@ -101,7 +101,17 @@ def gen_video(exec_folder, args):
     modelist = [format(i, '02d') for i in modelist]
     signals = ['pos', 'neg']
 
-    
+    # other args to find the right folders of pdbs
+    if args.step:
+        step=float(args.step[0])
+    else:
+        step=0.1
+
+    if args.dstep:
+        dstep=float(args.dstep[0])
+    else:
+        dstep=0.01
+
     # ensure the width and height inputs are within allowed ranges
     if (args.res[0] < 16 or args.res[0] > 8192) or (args.res[1] < 16 or args.res[1] > 8192):
         print("width or heigth out of range [16, 8192]")
@@ -160,14 +170,14 @@ def gen_video(exec_folder, args):
                         #os.system("rm -r " + commandfilebase + "/*")
                         pass
 
-                # for both directions(neg and pos)
+                # for both directions (neg and pos)
                 for sign in signals:
 
                     # this is where the relevant pdbs are located
-                    currfolder = folder + "/Runs/" + str(cut) + "/Mode" + mode + "-" + sign
+                    currfolder = folder + "/Runs_step" + str(step) + "_dstep" + str(dstep) + "/" + str(cut) + "/Mode" + mode + "-" + sign
 
                     # this is where the video will be put and what it will be called
-                    videoname =  folder + commandfilebase + "/Run-" + str(cut) + "-mode" + mode + "-" + sign + fileextension
+                    videoname =  folder + commandfilebase + "/Runs_step" + str(step) + "_dstep" + str(dstep) + "/" + str(cut) + "-mode" + mode + "-" + sign + fileextension
 
                     # copy tmp_RCD.pdb so it can be accessed as tmp_froda_00000000.pdb
                     os.system('chmod 744 '+currfolder+'/tmp_RCD.pdb')
@@ -187,8 +197,8 @@ def gen_video(exec_folder, args):
                 if args.combi:
 
                     # create a videolist file (specifying the videos to combine) to give ffmpeg
-                    filename  = folder + commandfilebase + "/Run-" + str(cut) + "-mode" + mode + "-"
-                    videolist = folder + commandfilebase + "/Run-" + str(cut) + "-mode" + mode + "-list" 
+                    filename  = folder + commandfilebase + "/Runs_step" + str(step) + "_dstep" + str(dstep) + "/" + str(cut) + "-mode" + mode + "-"
+                    videolist = folder + commandfilebase + "/Runs_step" + str(step) + "_dstep" + str(dstep) + "/" + str(cut) + "-mode" + mode + "-list" 
                     outF = open(videolist, "w")
                     print("file " + filename+'pos'+fileextension, end="\n", file=outF)
                     print("file " + filename+'neg'+fileextension, end="", file=outF)

--- a/generate_video_serial.py
+++ b/generate_video_serial.py
@@ -71,11 +71,10 @@ gen_video: takes a structured folder full of PDB files for conformers and genera
 Inputs:
 string exec_folder: folder where the python scripts are located (full path)
 struct args: structure containing all arguments already parsed
-string folder: folder where the PDB files to be turned into videos are located (full path)
 
 
 '''
-def gen_video(exec_folder, args, folder):
+def gen_video(exec_folder, args):
     
     print ("---------------------------------------------------------------")
     print ("gen_video:")
@@ -131,6 +130,8 @@ def gen_video(exec_folder, args, folder):
     if args.videocodec == "hevc":
         fileextension = ".mov"
 
+    # set present working directory
+    folder = os.getcwd()
 
     print ("---------------------------------------------------------------")
     print ("gen_video: converting from pdb files to videos")

--- a/generate_video_serial.py
+++ b/generate_video_serial.py
@@ -3,6 +3,7 @@ generate_video.py - takes a series of PDB files and generates a video
 
 '''
 
+from __future__ import print_function
 import sys
 import os
 #import multiprocessing
@@ -176,8 +177,8 @@ def gen_video(exec_folder, args, folder):
                 filename = folder+"/Run-"+str(cut)+"-mode"+mode+"-"
                 videolist = folder + "/Run-" + str(cut) + "-mode" + mode + "-list" 
                 outF = open(videolist, "w")
-                print >>outF, "file " + filename+'pos'+fileextension
-                print >>outF, "file " + filename+'neg'+fileextension
+                print("file " + filename+'pos'+fileextension, end="\n", file=outF)
+                print("file " + filename+'neg'+fileextension, end="", file=outF)
                 outF.close()
 
                 #run ffmpeg to create the combi

--- a/generate_video_serial.py
+++ b/generate_video_serial.py
@@ -3,12 +3,13 @@ generate_video.py - takes a series of PDB files and generates a video
 
 '''
 
+
 from __future__ import print_function
 import sys
 import os
 #import multiprocessing
 import argparse
-import subprocess
+
 
 '''
 parsing_video_args: takes all command-line arguments and parse them into a structure with argument fields
@@ -21,7 +22,6 @@ Outputs:
 structure args: structured object with fields corresponding to the possible parameters from command line
 
 '''
-
 def parsing_video_args(sys_args):
 
     # the argparse library takes care of all the parsing from a list of command-line arguments to a structure
@@ -53,10 +53,12 @@ def parsing_video_args(sys_args):
     args = parser.parse_args(sys_args[1:])
     return args
 
+
+
 '''
 call_pymol: simple wrapper for calling a Linux command
-'''
 
+'''
 '''
 def call_pymol(command):
     name = multiprocessing.current_process().name
@@ -65,13 +67,14 @@ def call_pymol(command):
     print('--- exiting:', name)
 '''
 
+
+
 '''
 gen_video: takes a structured folder full of PDB files for conformers and generate videos out of them
 
 Inputs:
 string exec_folder: folder where the python scripts are located (full path)
 struct args: structure containing all arguments already parsed
-
 
 '''
 def gen_video(exec_folder, args):
@@ -97,35 +100,35 @@ def gen_video(exec_folder, args):
     signals = ['pos', 'neg']
 
     
-    #ensure the width and height inputs are within allowed ranges
+    # ensure the width and height inputs are within allowed ranges
     if (args.res[0] < 16 or args.res[0] > 8192) or (args.res[1] < 16 or args.res[1] > 8192):
         print("width or heigth out of range [16, 8192]")
         return
 
-    #ensure the fps input is within allowed ranges
+    # ensure the fps input is within allowed ranges
     if (args.fps < 1 or args.fps > 240):
         print("fps out of range [1, 240]")
         return
 
 
-    #ensure the drawingengine input is an allowed option
+    # ensure the drawingengine input is an allowed option
     if args.drawingengine != "pymol" and args.drawingengine != "vmd":
         print("drawingengine invalid")
         return
 
 
-    #set commandfile to inputted path, including none by default
+    # set commandfile to inputted path, including none by default
     commandfile = ""
 
     if args.video:
         commandfile = args.video
 
-    #ensure the videocodec input is an allowed option
+    # ensure the videocodec input is an allowed option
     if args.videocodec != "mp4" and args.videocodec != "hevc":
         print("videocodec invalid")
         return
 
-    #set the fileextension according to the videocodec chosen
+    # set the fileextension according to the videocodec chosen
     fileextension = ".mp4"
     if args.videocodec == "hevc":
         fileextension = ".mov"
@@ -161,18 +164,9 @@ def gen_video(exec_folder, args):
 					args.drawingengine + '.sh ' + str(args.res[0]) + ' ' + str(args.res[1]) + ' ' + 
 					str(args.fps) + ' ' + currfolder+' '+videoname + ' ' + args.videocodec + ' ' + 
 					''.join([str(i) for i in commandfile]))
-
     
-    # now we loop over cutoffs and modes, and combine movies if --combi is specified
-    if args.combi:
-
-        print ("---------------------------------------------------------------")
-        print ("gen_video: finalizing - creating combi videos")
-        print ("----------------------------------------------------------------")
-
-        #if --combi is specified, create .combi videos from the pos and neg videos
-        for cut in cutlist:
-            for mode in modelist:
+            # combine the pos and neg videos into if desired
+            if args.combi:
 
                 #create a videolist file (specifying the videos to combine) to give ffmpeg
                 filename = folder+"/Run-"+str(cut)+"-mode"+mode+"-"
@@ -191,6 +185,8 @@ def gen_video(exec_folder, args):
 
     return
 
+
+
 # cmd.set(full_screen='on')
 
 # cut below here and paste into script ###
@@ -203,16 +199,17 @@ def gen_video(exec_folder, args):
 
 
 
-# if we're running this as a separate script, we need to parse arguments and then call gen_video, that's pretty much it!
+# calling this script by itself works but is inadvisable
+
 if __name__ == "__main__":
     args = parsing_video_args(sys.argv)
 
-    # set exec_folder to the full path of this script
+    # set exec_folder to the full path of the location of this script
     exec_folder=os.path.dirname(os.path.abspath(sys.argv[0]))
 
-    folder = args.folder[0]
-    os.chdir(folder)
+    # go into the output folder
+    os.chdir(args.folder[0])
 
     # pymol_test()
     # prepare_script(sys.argv,"t1t.mpg")
-    gen_video(exec_folder, args, folder)
+    gen_video(exec_folder, args)

--- a/helpers.py
+++ b/helpers.py
@@ -120,5 +120,5 @@ def go_to_output_folder(args):
 
     #enter a subfolder for specific kept molecules if necessary
     if (not args.keep==[]):
-        os.system("mkdir -p " + '_'.join(args.keep))
-        os.chdir('_'.join(args.keep))
+        os.system("mkdir -p keep-" + '_'.join(args.keep))
+        os.chdir("keep-" + '_'.join(args.keep))

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,102 @@
+'''
+this contains some useful helper functions used throughout the project
+'''
+
+import os
+import argparse
+
+'''
+parsing_args: takes all command-line arguments and parse them into a structure with argument fields
+
+Inputs:
+list sys_args: list of system arguments as received in the command line
+
+Outputs:
+structure args: structured object with fields corresponding to the possible parameters from command line
+'''
+
+def parsing_args(sys_args):
+
+    # the argparse library takes care of all the parsing from a list of
+    # command-line arguments to a structure
+    parser = argparse.ArgumentParser(description='Runs simulations and generates videos for the most likely movement modes given a PDB file.',usage='%(prog)s pdbfile [options]')
+
+    parser.add_argument('--keep',  nargs="+",
+                        help='List of molecules to be kept')
+    parser.add_argument('--output',  nargs=1,
+                        help='Output directory')
+    parser.add_argument('--res',  nargs=2, type=int, default=[640, 480], 
+                        help='Video resolution (width, height), range [16, 8192]')
+    parser.add_argument('--waters',  action='store_true',
+                        help='Flag for keeping water molecules')
+    parser.add_argument('--multiple',  action='store_true',
+                        help='Keep multiple chains (default: uses only chain A)')
+    parser.add_argument('--nomovie',  action='store_true',
+                        help='Stop calculation after FRODA and before any attempt to generate images and movies')
+    parser.add_argument('--combi',  action='store_true',
+                        help='Combine both positive and negative directions into a single movie')
+    parser.add_argument('--threed',  action='store_true',
+                        help='Flag for generating anaglyph stereo movies')
+    parser.add_argument('--confs',  nargs=1,
+                        help='Total number of configurations to be calculated')
+    parser.add_argument('--freq',  nargs=1,
+                        help='Frequency of saving intermediate configurations')
+    parser.add_argument('--step',  nargs=1,
+                        help='Size of random step')
+    parser.add_argument('--dstep',  nargs=1,
+                        help='Size of directed step')
+    parser.add_argument('--modes',  nargs="+",
+                        help='Movement modes to be investigated')
+    parser.add_argument('--ecuts',  nargs="+",
+                        help='Energy cutoff values')
+    parser.add_argument('--video',  nargs=1,
+                        help='File with PyMOL or VMD commands to be run before generating video')
+    parser.add_argument('pdbfile', metavar='PDB', type=str, nargs=1,
+                        help='Initial PDB file')
+    parser.add_argument('--videocodec', type=str, default="mp4", 
+                        help="Use 'mp4' or 'hevc' to enode the videos, resulting in .mp4 or .mov files (defaults to mp4)")
+    parser.add_argument('--drawingengine', type=str, default="pymol", 
+                        help="Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now)")
+    parser.add_argument('--fps',  nargs=1, type=int, default=30,
+                        help='Frames per second of the videos, range [1, 240]')
+
+    # actually do the parsing for all system args other than 0
+    # (which is the python script name) and return the structure generated
+    args = parser.parse_args(sys_args[1:])
+
+    #ensure pdbfile and output are full paths, not relative ones (so they are correct from here on, regardless of pwd)
+    args.pdbfile[0] = os.path.abspath(args.pdbfile[0])
+    if (args.output):
+        args.output[0] = os.path.abspath(args.output[0])
+    
+    return args
+
+
+'''
+go_to_output_folder: creates or (if necessary) empties output folder and enters it,
+                     and warns user before deletions if necessary
+
+Inputs:
+argument list args: object containing all command-line arguments as parsed by pdb2movie
+
+Outputs:
+None
+'''
+
+def go_to_output_folder(args):
+
+    # make or (if necessary) empty the output folder, warning the user before any emptying occurs
+    try:
+        os.mkdir(args.output[0])
+    except Exception:
+        #try:
+        #    userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+        #except NameError:
+        #    userinput=input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+        #if (userinput=="y"):
+            os.system("rm -r -f "+args.output[0]+"/*")
+        #else:
+        #    quit()
+
+    #enter the output folder
+    os.chdir(args.output[0])

--- a/helpers.py
+++ b/helpers.py
@@ -21,10 +21,14 @@ def parsing_args(sys_args):
     # command-line arguments to a structure
     parser = argparse.ArgumentParser(description='Runs simulations and generates videos for the most likely movement modes given a PDB file.',usage='%(prog)s pdbfile [options]')
 
+    parser.add_argument('--output',  nargs=1,
+                        help='Set the output location for the videos, defaulting to `FILE` without the `.pdb`')
+    parser.add_argument('--overwrite',  action='store_true',
+                        help='Delete the contents of the output folder before beginning')
+    parser.add_argument('--forceoverwrite',  action='store_true',
+                        help='Overwrite and silence all are-you-sure messages')
     parser.add_argument('--keep',  nargs="+",
                         help='List of molecules to be kept')
-    parser.add_argument('--output',  nargs=1,
-                        help='Output directory')
     parser.add_argument('--res',  nargs=2, type=int, default=[640, 480], 
                         help='Video resolution (width, height), range [16, 8192]')
     parser.add_argument('--waters',  action='store_true',
@@ -89,14 +93,18 @@ def go_to_output_folder(args):
     try:
         os.mkdir(args.output[0])
     except Exception:
-        #try:
-        #    userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
-        #except NameError:
-        #    userinput=input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
-        #if (userinput=="y"):
+        if (args.forceoverwrite):
             os.system("rm -r -f "+args.output[0]+"/*")
-        #else:
-        #    quit()
+        elif (args.overwrite):
+
+            try:
+                userinput=raw_input("WARNING: --overwrite option chosen. Everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+            except NameError:
+                userinput=input("WARNING: --overwrite option chosen. everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+            if (userinput=="y"):
+                os.system("rm -r -f "+args.output[0]+"/*")
+            else:
+                quit()
 
     #enter the output folder
     os.chdir(args.output[0])

--- a/helpers.py
+++ b/helpers.py
@@ -68,10 +68,17 @@ def parsing_args(sys_args):
     # (which is the python script name) and return the structure generated
     args = parser.parse_args(sys_args[1:])
 
-    #ensure pdbfile and output are full paths, not relative ones (so they are correct from here on, regardless of pwd)
+    # ensure pdbfile and output are full paths, not relative ones (so they are correct from here on, regardless of pwd)
     args.pdbfile[0] = os.path.abspath(args.pdbfile[0])
     if (args.output):
         args.output[0] = os.path.abspath(args.output[0])
+
+    # correct and order args.keep
+    if (args.keep==None):
+        args.keep=[]
+    if args.waters:
+        args.keep.append('HOH')
+    args.keep.sort()
     
     return args
 
@@ -108,3 +115,8 @@ def go_to_output_folder(args):
 
     #enter the output folder
     os.chdir(args.output[0])
+
+    #enter a subfolder for specific kept molecules if necessary
+    if (not args.keep==[]):
+        os.system("mkdir -p " + '_'.join(args.keep))
+        os.chdir('_'.join(args.keep))

--- a/helpers.py
+++ b/helpers.py
@@ -30,7 +30,7 @@ def parsing_args(sys_args):
                         help='Delete the contents of the output folder before beginning')
     parser.add_argument('--forceoverwrite',  action='store_true',
                         help='Overwrite and silence all are-you-sure messages')
-    parser.add_argument('--keep',  nargs="+",
+    parser.add_argument('--keep',  nargs="+", default=[],
                         help='List of molecules to be kept')
     parser.add_argument('--res',  nargs=2, type=int, default=[640, 480], 
                         help='Video resolution (width, height), range [16, 8192]')
@@ -44,15 +44,15 @@ def parsing_args(sys_args):
                         help='Combine both positive and negative directions into a single movie')
     parser.add_argument('--threed',  action='store_true',
                         help='Flag for generating anaglyph stereo movies')
-    parser.add_argument('--confs',  nargs=1,
+    parser.add_argument('--confs',  nargs=1, type=int,
                         help='Total number of configurations to be calculated')
-    parser.add_argument('--freq',  nargs=1,
+    parser.add_argument('--freq',  nargs=1, type=int,
                         help='Frequency of saving intermediate configurations')
     parser.add_argument('--step',  nargs=1,
                         help='Size of random step')
     parser.add_argument('--dstep',  nargs=1,
                         help='Size of directed step')
-    parser.add_argument('--modes',  nargs="+",
+    parser.add_argument('--modes',  nargs="+", type=int, default=[7, 8],
                         help='Movement modes to be investigated')
     parser.add_argument('--ecuts',  nargs="+",
                         help='Energy cutoff values')
@@ -77,11 +77,12 @@ def parsing_args(sys_args):
         args.output[0] = os.path.abspath(args.output[0])
 
     # correct and order args.keep
-    if (args.keep==None):
-        args.keep=[]
     if args.waters:
         args.keep.append('HOH')
     args.keep.sort()
+
+    # order modes
+    args.modes.sort()
     
     return args
 

--- a/helpers.py
+++ b/helpers.py
@@ -1,9 +1,12 @@
 '''
-this contains some useful helper functions used throughout the project
+helpers.py - this contains some useful helper functions used throughout the project
+
 '''
+
 
 import os
 import argparse
+
 
 '''
 parsing_args: takes all command-line arguments and parse them into a structure with argument fields
@@ -13,8 +16,8 @@ list sys_args: list of system arguments as received in the command line
 
 Outputs:
 structure args: structured object with fields corresponding to the possible parameters from command line
-'''
 
+'''
 def parsing_args(sys_args):
 
     # the argparse library takes care of all the parsing from a list of
@@ -83,6 +86,7 @@ def parsing_args(sys_args):
     return args
 
 
+
 '''
 go_to_output_folder: creates or (if necessary) empties output folder and enters it,
                      and warns user before deletions if necessary
@@ -90,10 +94,7 @@ go_to_output_folder: creates or (if necessary) empties output folder and enters 
 Inputs:
 argument list args: object containing all command-line arguments as parsed by pdb2movie
 
-Outputs:
-None
 '''
-
 def go_to_output_folder(args):
 
     # make or (if necessary) empty the output folder, warning the user before any emptying occurs

--- a/helpers.py
+++ b/helpers.py
@@ -56,8 +56,8 @@ def parsing_args(sys_args):
                         help='Movement modes to be investigated')
     parser.add_argument('--ecuts',  nargs="+",
                         help='Energy cutoff values')
-    parser.add_argument('--video',  nargs=1,
-                        help='File with PyMOL or VMD commands to be run before generating video')
+    parser.add_argument('--video',  nargs="+", type=str,
+                        help='File(s) with PyMOL or VMD commands to be run before generating video')
     parser.add_argument('pdbfile', metavar='PDB', type=str, nargs=1,
                         help='Initial PDB file')
     parser.add_argument('--videocodec', type=str, default="mp4", 

--- a/make_video_pymol.sh
+++ b/make_video_pymol.sh
@@ -1,23 +1,25 @@
 #!/bin/bash
 
 #check that five arguments have been given
-if [ "$#" -ne 6 ] && [ "$#" -ne 7 ]
+if [ "$#" -ne 8 ] && [ "$#" -ne 9 ]
 then
-  echo "usage: $0 video_width video_height frame_rate path_with_pdb_files destination_file_name_and_path video_codec [pymol_command_file]"
+  echo "usage: $0 video_width video_height frame_rate path_with_pdb_files destination_file_name_and_path video_codec confs freq [pymol_command_file]"
   exit -1
 fi
 
 #arguments:
 #PDB_PATH is where to find the PDBs which must begin 'tmp_froda_'.
 #DEST_FILE is the name (and location) of the video to generate
-#OTIONAL_COMMAND_FILE is optional, and allows extra instructions to be given to pymol before generation of frames
+#OPTIONAL_COMMAND_FILE is optional, and allows extra instructions to be given to pymol before generation of frames
 VIDEO_WIDTH=$1
 VIDEO_HEIGHT=$2
 FPS=$3
 PDB_PATH=$4
 DEST_FILE=$5
 VIDEO_CODEC=$6
-OPTIONAL_COMMAND_FILE=$7
+CONFS=$7
+FREQ=$8
+OPTIONAL_COMMAND_FILE=$9
 
 TMP_PATH=$PDB_PATH/pymol_temp
 
@@ -60,11 +62,35 @@ fi
 
 echo "cmd.save(\"$PDB_PATH/cartoon.pse\")" >> $CMD_FILE
 
-
 COUNTER=0
 
 for i in `ls $PDB_FILES`
 do
+
+  #get the filename, and extract the conformer number
+  j="$(basename -- $i)"
+  j=${j:10:8}
+  if [ "$j" -eq "00000000" ]
+  then
+    j=0
+  else
+    j=$(echo $j | sed 's/^0*//')
+  fi
+
+  #check if we want to use this pdb; if not, then skip it
+
+  #its number must be less than CONFS...
+  if (( $j > $CONFS ))
+  then
+    continue
+  fi
+
+  #...and must be a multiple of FREQ
+  if (( $j % $FREQ != 0 ))
+  then
+    continue
+  fi
+
   #id of the next frame (png file) to generate
   id=$(printf "%08d" $COUNTER)
 

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -82,7 +82,7 @@ def parsing_args(sys_args):
 
 if __name__ == "__main__":#
 
-    # first things first: we need to parse command-line arguments with the function we have defined
+    # parse commmand-line arguments
     args=parsing_args(sys.argv)
 
     # print "test"
@@ -94,42 +94,25 @@ if __name__ == "__main__":#
     # set exec_folder to the full path of this script
     exec_folder=os.path.dirname(os.path.abspath(sys.argv[0]))
 
-    #print(exec_folder)
-
-    # if an output folder was defined, we need to make that directory if it doesn't exist,
-    # and warn the user that the folder will be emptied if it exists
-    # and then make that the present working directory
-    #if (args.output):
-
-    #    try:
-    #        os.mkdir(args.output[0])
-    #        os.chdir(args.output[0])
-    #    except Exception:
-    #        try:
-    #            userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
-    #        except NameError:
-    #            userinput=input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
-    #        if (userinput=="y"):
-    #            os.system("rm -r "+args.output[0]+"/*")
-    #            os.chdir(args.output[0])
-    #        else:
-    #            quit()
-    #        pass
-
-
     # set the output folder if not specified
     if (not args.output):
         args.output = [args.pdbfile[0][:-4]]
 
-    # make or (if necessary) empty the output folder
+    # make or (if necessary) empty the output folder, warning the user before any emptying occurs
     try:
-        os.mkdir(args.pdbfile[0][:-4])
-        os.chdir(args.pdbfile[0][:-4])
+        os.mkdir(args.output[0])
     except Exception:
-        os.system("rm -r "+args.pdbfile[0][:-4]+"/*")
-        os.chdir(args.pdbfile[0][:-4])
-        pass
+        #try:
+        #    userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+        #except NameError:
+        #    userinput=input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+        if (userinput=="y"):
+            os.system("rm -r "+args.output[0]+"/*")
+        else:
+            quit()
 
+    #enter the output folder
+    os.chdir(args.output[0])
 
     # now we will just call the functions defined in other files in sequence
     # and that's all we need to do!

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -99,33 +99,37 @@ if __name__ == "__main__":#
     # if an output folder was defined, we need to make that directory if it doesn't exist,
     # and warn the user that the folder will be emptied if it exists
     # and then make that the present working directory
-    if (args.output):
+    #if (args.output):
 
-        try:
-            os.mkdir(args.output[0])
-            os.chdir(args.output[0])
-        except Exception:
-            try:
-                userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
-            except NameError:
-                userinput=input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
-            if (userinput=="y"):
-                os.system("rm -r "+args.output[0]+"/*")
-                os.chdir(args.output[0])
-            else:
-                quit()
-            pass
+    #    try:
+    #        os.mkdir(args.output[0])
+    #        os.chdir(args.output[0])
+    #    except Exception:
+    #        try:
+    #            userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+    #        except NameError:
+    #            userinput=input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+    #        if (userinput=="y"):
+    #            os.system("rm -r "+args.output[0]+"/*")
+    #            os.chdir(args.output[0])
+    #        else:
+    #            quit()
+    #        pass
 
-    # if we haven't specified an output folder, we make a subfolder at current directory with the protein name (or empty an existing subfolder)
-    else:
 
-        try:
-            os.mkdir(args.pdbfile[0][:-4])
-            os.chdir(args.pdbfile[0][:-4])
-        except Exception:
-            os.system("rm -r "+args.pdbfile[0][:-4]+"/*")
-            os.chdir(args.pdbfile[0][:-4])
-            pass
+    # set the output folder if not specified
+    if (not args.output):
+        args.output = [args.pdbfile[0][:-4]]
+
+    # make or (if necessary) empty the output folder
+    try:
+        os.mkdir(args.pdbfile[0][:-4])
+        os.chdir(args.pdbfile[0][:-4])
+    except Exception:
+        os.system("rm -r "+args.pdbfile[0][:-4]+"/*")
+        os.chdir(args.pdbfile[0][:-4])
+        pass
+
 
     # now we will just call the functions defined in other files in sequence
     # and that's all we need to do!

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -52,9 +52,6 @@ if __name__ == "__main__":#
     print ("----------------------------------------------------------------")
     hydro_file=runfirst.firstsim(exec_folder,args,clean_file)
 
-    # we get the folder path because we forgot to save it when creating/emptying it beforehand
-    folder=os.path.abspath(hydro_file.rsplit("/",1)[0])
-
     # these don't even have outputs that need to be saved:
     # first we run ElNemo...
     print ("---------------------------------------------------------------")
@@ -78,7 +75,7 @@ if __name__ == "__main__":#
         print ("---------------------------------------------------------------")
         print ("pdb2movie: generating the videos")
         print ("----------------------------------------------------------------")
-        generate_video_serial.gen_video(exec_folder,args,folder)
+        generate_video_serial.gen_video(exec_folder,args)
         
     # finally, we are done
     print ("---------------------------------------------------------------")

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -73,7 +73,8 @@ def parsing_args(sys_args):
 
     #ensure pdbfile and output are full paths, not relative ones (so they are correct from here on, regardless of pwd)
     args.pdbfile[0] = os.path.abspath(args.pdbfile[0])
-    args.output[0] = os.path.abspath(args.output[0])
+    if (args.output):
+		args.output[0] = os.path.abspath(args.output[0])
     
     return args
 

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -1,7 +1,9 @@
 '''
 pdb2movie.py - this is where the main program lives! 
 it binds together all other functions defined in the other python scripts.
+
 '''
+
 
 import sys
 import os

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -74,7 +74,7 @@ def parsing_args(sys_args):
     #ensure pdbfile and output are full paths, not relative ones (so they are correct from here on, regardless of pwd)
     args.pdbfile[0] = os.path.abspath(args.pdbfile[0])
     if (args.output):
-		args.output[0] = os.path.abspath(args.output[0])
+	    args.output[0] = os.path.abspath(args.output[0])
     
     return args
 
@@ -105,7 +105,10 @@ if __name__ == "__main__":#
             os.mkdir(args.output[0])
             os.chdir(args.output[0])
         except Exception:
-            userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+            try:
+                userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+            except NameError:
+                userinput=input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
             if (userinput=="y"):
                 os.system("rm -r "+args.output[0]+"/*")
                 os.chdir(args.output[0])

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -78,6 +78,37 @@ def parsing_args(sys_args):
     
     return args
 
+
+'''
+go_to_output_folder: creates or (if necessary) empties output folder and enters it,
+                     and warns user before deletions if necessary
+
+Inputs:
+argument list args: object containing all command-line arguments as parsed by pdb2movie
+
+Outputs:
+None
+'''
+
+def go_to_output_folder(args):
+
+    # make or (if necessary) empty the output folder, warning the user before any emptying occurs
+    try:
+        os.mkdir(args.output[0])
+    except Exception:
+        #try:
+        #    userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+        #except NameError:
+        #    userinput=input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
+        #if (userinput=="y"):
+            os.system("rm -r -f "+args.output[0]+"/*")
+        #else:
+        #    quit()
+
+    #enter the output folder
+    os.chdir(args.output[0])
+
+
 # no specific function is defined here, since this is our main program!
 
 if __name__ == "__main__":#
@@ -98,21 +129,8 @@ if __name__ == "__main__":#
     if (not args.output):
         args.output = [args.pdbfile[0][:-4]]
 
-    # make or (if necessary) empty the output folder, warning the user before any emptying occurs
-    try:
-        os.mkdir(args.output[0])
-    except Exception:
-        #try:
-        #    userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
-        #except NameError:
-        #    userinput=input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
-        if (userinput=="y"):
-            os.system("rm -r "+args.output[0]+"/*")
-        else:
-            quit()
-
-    #enter the output folder
-    os.chdir(args.output[0])
+    # organise the output folder
+    go_to_output_folder(args)
 
     # now we will just call the functions defined in other files in sequence
     # and that's all we need to do!
@@ -121,7 +139,7 @@ if __name__ == "__main__":#
     print ("---------------------------------------------------------------")
     print ("pdb2movie: cleaning the PDB file")
     print ("----------------------------------------------------------------")
-    clean_file=cleanpdb.cleanPDB(args,exec_folder)
+    clean_file=cleanpdb.cleanPDB(args)
 
     # then we run FIRST on it
     print ("---------------------------------------------------------------")
@@ -130,8 +148,8 @@ if __name__ == "__main__":#
     hydro_file=runfirst.firstsim(exec_folder,args,clean_file)
 
     # we get the folder path because we forgot to save it when creating/emptying it beforehand
-    folder=hydro_file.rsplit("/",1)[0]
-    
+    folder=os.path.abspath(hydro_file.rsplit("/",1)[0])
+
     # these don't even have outputs that need to be saved:
     # first we run ElNemo...
     print ("---------------------------------------------------------------")

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -5,108 +5,13 @@ it binds together all other functions defined in the other python scripts.
 
 import sys
 import os
+
+import helpers
 import cleanpdb
 import runfirst
 import runelnemo
 import runfroda
 import generate_video_serial
-import argparse
-
-'''
-parsing_args: takes all command-line arguments and parse them into a structure with argument fields
-
-Inputs:
-list sys_args: list of system arguments as received in the command line
-
-Outputs:
-structure args: structured object with fields corresponding to the possible parameters from command line
-'''
-
-def parsing_args(sys_args):
-
-    # the argparse library takes care of all the parsing from a list of
-    # command-line arguments to a structure
-    parser = argparse.ArgumentParser(description='Runs simulations and generates videos for the most likely movement modes given a PDB file.',usage='%(prog)s pdbfile [options]')
-
-    parser.add_argument('--keep',  nargs="+",
-                        help='List of molecules to be kept')
-    parser.add_argument('--output',  nargs=1,
-                        help='Output directory')
-    parser.add_argument('--res',  nargs=2, type=int, default=[640, 480], 
-                        help='Video resolution (width, height), range [16, 8192]')
-    parser.add_argument('--waters',  action='store_true',
-                        help='Flag for keeping water molecules')
-    parser.add_argument('--multiple',  action='store_true',
-                        help='Keep multiple chains (default: uses only chain A)')
-    parser.add_argument('--nomovie',  action='store_true',
-                        help='Stop calculation after FRODA and before any attempt to generate images and movies')
-    parser.add_argument('--combi',  action='store_true',
-                        help='Combine both positive and negative directions into a single movie')
-    parser.add_argument('--threed',  action='store_true',
-                        help='Flag for generating anaglyph stereo movies')
-    parser.add_argument('--confs',  nargs=1,
-                        help='Total number of configurations to be calculated')
-    parser.add_argument('--freq',  nargs=1,
-                        help='Frequency of saving intermediate configurations')
-    parser.add_argument('--step',  nargs=1,
-                        help='Size of random step')
-    parser.add_argument('--dstep',  nargs=1,
-                        help='Size of directed step')
-    parser.add_argument('--modes',  nargs="+",
-                        help='Movement modes to be investigated')
-    parser.add_argument('--ecuts',  nargs="+",
-                        help='Energy cutoff values')
-    parser.add_argument('--video',  nargs=1,
-                        help='File with PyMOL or VMD commands to be run before generating video')
-    parser.add_argument('pdbfile', metavar='PDB', type=str, nargs=1,
-                        help='Initial PDB file')
-    parser.add_argument('--videocodec', type=str, default="mp4", 
-                        help="Use 'mp4' or 'hevc' to enode the videos, resulting in .mp4 or .mov files (defaults to mp4)")
-    parser.add_argument('--drawingengine', type=str, default="pymol", 
-                        help="Use 'vmd' or 'pymol' to render pdb files to frames (defaults to pymol for now)")
-    parser.add_argument('--fps',  nargs=1, type=int, default=30,
-                        help='Frames per second of the videos, range [1, 240]')
-
-    # actually do the parsing for all system args other than 0
-    # (which is the python script name) and return the structure generated
-    args = parser.parse_args(sys_args[1:])
-
-    #ensure pdbfile and output are full paths, not relative ones (so they are correct from here on, regardless of pwd)
-    args.pdbfile[0] = os.path.abspath(args.pdbfile[0])
-    if (args.output):
-	    args.output[0] = os.path.abspath(args.output[0])
-    
-    return args
-
-
-'''
-go_to_output_folder: creates or (if necessary) empties output folder and enters it,
-                     and warns user before deletions if necessary
-
-Inputs:
-argument list args: object containing all command-line arguments as parsed by pdb2movie
-
-Outputs:
-None
-'''
-
-def go_to_output_folder(args):
-
-    # make or (if necessary) empty the output folder, warning the user before any emptying occurs
-    try:
-        os.mkdir(args.output[0])
-    except Exception:
-        #try:
-        #    userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
-        #except NameError:
-        #    userinput=input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
-        #if (userinput=="y"):
-            os.system("rm -r -f "+args.output[0]+"/*")
-        #else:
-        #    quit()
-
-    #enter the output folder
-    os.chdir(args.output[0])
 
 
 # no specific function is defined here, since this is our main program!
@@ -114,7 +19,7 @@ def go_to_output_folder(args):
 if __name__ == "__main__":#
 
     # parse commmand-line arguments
-    args=parsing_args(sys.argv)
+    args=helpers.parsing_args(sys.argv)
 
     # print "test"
     # if (args.threed):
@@ -129,8 +34,8 @@ if __name__ == "__main__":#
     if (not args.output):
         args.output = [args.pdbfile[0][:-4]]
 
-    # organise the output folder
-    go_to_output_folder(args)
+    # change directory to the output folder
+    helpers.go_to_output_folder(args)
 
     # now we will just call the functions defined in other files in sequence
     # and that's all we need to do!

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":#
     print ("---------------------------------------------------------------")
     print ("pdb2movie: starting rigidity analysis with FIRST")
     print ("----------------------------------------------------------------")
-    hydro_file=runfirst.firstsim(exec_folder,args,clean_file)
+    hydro_file=runfirst.firstsim(exec_folder, clean_file)
 
     # these don't even have outputs that need to be saved:
     # first we run ElNemo...

--- a/pdb2movie.py
+++ b/pdb2movie.py
@@ -71,8 +71,9 @@ def parsing_args(sys_args):
     # (which is the python script name) and return the structure generated
     args = parser.parse_args(sys_args[1:])
 
-    #ensure pdbfile has the full path
+    #ensure pdbfile and output are full paths, not relative ones (so they are correct from here on, regardless of pwd)
     args.pdbfile[0] = os.path.abspath(args.pdbfile[0])
+    args.output[0] = os.path.abspath(args.output[0])
     
     return args
 
@@ -103,7 +104,7 @@ if __name__ == "__main__":#
             os.mkdir(args.output[0])
             os.chdir(args.output[0])
         except Exception:
-            userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/n]   ")
+            userinput=raw_input("WARNING: everything in output folder will be deleted! Are you sure you want to continue? [y/N]   ")
             if (userinput=="y"):
                 os.system("rm -r "+args.output[0]+"/*")
                 os.chdir(args.output[0])

--- a/runelnemo.py
+++ b/runelnemo.py
@@ -36,9 +36,8 @@ def elnemosim(exec_folder, args, hydropdb):
     print ("elnemosim: generate structure file")
     print ("----------------------------------------------------------------")
 
-    
     if (os.path.isfile(hydropdb[:-10] + ".structure")):
-        print("structure file already generated: " + hydropdb[:-10] + ".structure")
+        print("   structure file already generated: " + os.path.basename(hydropdb)[:-10] + ".structure")
         struct_file=hydropdb[:-10] + ".structure"
     else:
         struct_file=generate_structure(hydropdb)
@@ -51,7 +50,7 @@ def elnemosim(exec_folder, args, hydropdb):
     print ("----------------------------------------------------------------")
 
     if (os.path.isfile("pdbmat.dat")):
-        print("pdbmat options file already generated: pdbmat.dat")
+        print("   pdbmat options file already generated: pdbmat.dat")
     else:
         generate_pdbmat(struct_file)
 
@@ -65,7 +64,7 @@ def elnemosim(exec_folder, args, hydropdb):
         os.system(exec_folder+"/pdbmat")
         os.system("rm pdbmat_in_progress")
     else:
-        print("pdbmat already run")
+        print("   pdbmat already run")
 
     # now, we run diagstd
     print ("---------------------------------------------------------------")
@@ -77,7 +76,7 @@ def elnemosim(exec_folder, args, hydropdb):
         os.system(exec_folder + "/FIRST-190916-SAW/src/diagstd")
         os.system("rm diagstd_in_progress")
     else:
-        print("diagstd already run")
+        print("   diagstd already run")
 
 
     # these variables store the lowest and highest mode we must run modesplit with

--- a/runelnemo.py
+++ b/runelnemo.py
@@ -81,7 +81,7 @@ def elnemosim(exec_folder, args, hydropdb):
 
 
     # these variables store the lowest and highest mode we must run modesplit with
-    # the code here makes this rane as tight as possible, accounting for mode[num].in files already generated
+    # the code here makes this range as tight as possible, accounting for mode[num].in files already generated
     min_mode = modelist[0]
     max_mode = modelist[-1]
 
@@ -123,7 +123,6 @@ def generate_structure(filename):
 
     # let's open up the PDB file and generate a filename for the output file based on its path
     inputfile=open(filename,'r')
-    os.system("rm -f " + filename[:-10] + ".structure_temp")
 
     # now we open the output file as well
     outputfile=open(filename[:-10] + ".structure", 'w')
@@ -156,8 +155,7 @@ string struct_file: path to the .structure file that was already generated at th
 def generate_pdbmat(struct_file):
 
     # we start by creating a pdbmat.dat file and opening it
-    filename='pdbmat_temp.dat'
-    datfile=open(filename,'w')
+    datfile=open('pdbmat_temp.dat','w')
 
     # the only variable in this is the name of the struct file
     datfile.write("Coordinate FILENAME = " + os.path.basename(struct_file) + "\n")

--- a/runelnemo.py
+++ b/runelnemo.py
@@ -4,11 +4,11 @@ runelnemo.py - functions related to running Elastic Network model ElNemo
 '''
 
 
-
 import os
 import sys
 
 import helpers
+
 
 '''
 elnemosim: main function for running ElNemo simulations
@@ -19,7 +19,6 @@ Inputs:
 - string hydropdb: full path to PDB file after addition of hydrogens (by extension, also includes path to where all outputs are)
 
 '''
-
 def elnemosim(exec_folder, args, hydropdb):
 
     print ("---------------------------------------------------------------")
@@ -86,8 +85,6 @@ Outputs:
 string outputfile: path to the generated .structure file
 
 '''
-
-
 def generate_structure(filename):
 
     # let's open up the PDB file and generate a filename for the output file based on its path
@@ -110,6 +107,7 @@ def generate_structure(filename):
     return outputfilename
 
 
+
 '''
 generate_pdbmat: a simple wrapper to a bunch of write calls to generate a very specific pdbmat.dat file with the correct options for diagstd
 
@@ -117,8 +115,6 @@ Inputs:
 string struct_file: path to the .structure file that was already generated at this point
 
 '''
-
-
 def generate_pdbmat(struct_file):
 
     # we start by creating a pdbmat.dat file and opening it
@@ -140,8 +136,7 @@ def generate_pdbmat(struct_file):
     datfile.close()
 
 
-
-# calling this script by itself works as if it were pdb2movie works but is inadvisable
+# calling this script by itself works as if it were pdb2movie but is inadvisable
 
 if __name__ == "__main__":
     # parse commmand-line arguments

--- a/runelnemo.py
+++ b/runelnemo.py
@@ -8,6 +8,8 @@ runelnemo.py - functions related to running Elastic Network model ElNemo
 import os
 import sys
 
+import helpers
+
 '''
 elnemosim: main function for running ElNemo simulations
 
@@ -139,14 +141,13 @@ def generate_pdbmat(struct_file):
 
 
 
-
-# calling this script by itself is probably something you shouldn't do! But you can pass a filename for a PDB file with hydrogens and it should work, I guess?
+# calling this script by itself works as if it were pdb2movie works but is inadvisable
 
 if __name__ == "__main__":
     # parse commmand-line arguments
     args=helpers.parsing_args(sys.argv)
 
-    hydro=os.path.abspath(sys.argv[1])
+    hydro="./" + os.path.basename(sys.argv[1])[:-4] + "_hydro" + os.path.basename(sys.argv[1])[-4:]
 
     # set exec_folder to the full path of this script
     exec_folder=os.path.dirname(os.path.abspath(sys.argv[0]))
@@ -158,5 +159,4 @@ if __name__ == "__main__":
     # change directory to the output folder
     helpers.go_to_output_folder(args)
 
-
-    elnemosim(exec_folder,args,hydro)
+    elnemosim(exec_folder, args, hydro)

--- a/runfirst.py
+++ b/runfirst.py
@@ -72,7 +72,6 @@ def renum_atoms(filename):
 
     # open the input file and a temp file
     inputfile=open(filename,'r')
-    os.system("rm -f tmp.pdb")
     tempfile=open("tmp.pdb",'w')
 
     # let's learn how to count!

--- a/runfirst.py
+++ b/runfirst.py
@@ -53,7 +53,7 @@ def firstsim(exec_folder,cleanpdb):
 
     os.system(exec_folder+"/FIRST-190916-SAW/src/FIRST "+cleanpdb[:-9]+"hydro_temp.pdb -non -dil 1 -E -0 -covout -hbout -phout -srout -L "+exec_folder+"/FIRST-190916-SAW")
 
-    # rename the file to indicate it is complete (remove i[ncomplete])
+    # rename the file to indicate it is complete (remove "temp")
     os.system("mv " + cleanpdb[:-9] + "hydro_temp.pdb " + cleanpdb[:-9] + "hydro.pdb")
 
     # finally, return the hydro-added PDB path

--- a/runfirst.py
+++ b/runfirst.py
@@ -28,29 +28,17 @@ def firstsim(exec_folder,args,cleanpdb):
     print ("firstsim:")
     print ("----------------------------------------------------------------")
 
-    # print "./reduce.3.23.130521 -DB reduce_het_dict.txt -build "+cleanpdb+" > "+cleanpdb[:-9]+"hydro.pdb"
-
-    # first we isolate the name of the protein, which is in the clean PDB path somewhere!
-    print ("---------------------------------------------------------------")
-    print ("firstsim: find name of protein")
-    print ("----------------------------------------------------------------")
-
-    prot=cleanpdb[:-10].rsplit("/",1)[1]
-    # print "prot is "+prot
-
     # now, we need to run reduce to add hydrogens to protein residues - this generates a PDB file with hydrogens
 
     print ("---------------------------------------------------------------")
     print ("firstsim: calling reduce.3.23.130521")
     print ("----------------------------------------------------------------")
 
+    # print              "./reduce.3.23.130521 -DB "+exec_folder+"/reduce_het_dict.txt -build "+cleanpdb+" > "+cleanpdb[:-9]+ "hydro.pdb"
     os.system(exec_folder+"/reduce.3.23.130521 -DB "+exec_folder+"/reduce_het_dict.txt -build "+cleanpdb+" > "+cleanpdb[:-9]+"hydro.pdb")
 
-    # we also isolate the folder where outputs are being saved
-    folder=cleanpdb.rsplit("/",1)[0]
-
     # now, we call an external function to renumber the atoms taking the hydrogens into account
-    renum_atoms(cleanpdb[:-9]+"hydro.pdb",folder)
+    renum_atoms(cleanpdb[:-9]+"hydro.pdb")
 
     # finally we run FIRST with the PDB after hydrogen addition!
 
@@ -62,7 +50,6 @@ def firstsim(exec_folder,args,cleanpdb):
 
     # finally, return the hydro-added PDB path
     return cleanpdb[:-9]+"hydro.pdb"
-    # print folder,prot
 
 
 '''
@@ -70,21 +57,18 @@ renum_atoms: renumber the atoms in a PDB file to make sure they're in order and
 
 Inputs:
 string filename: path to origin PDB file
-string folder: path to output folder
 
 '''
 
 
-def renum_atoms(filename,folder):
+def renum_atoms(filename):
 
-    # open the input file and a temp file at the output folder
+    # open the input file and a temp file
     inputfile=open(filename,'r')
-    tempfile=open(folder+"/tmp.pdb",'w')
+    tempfile=open("tmp.pdb",'w')
 
     # let's learn how to count!
     counter=1
-    # test=format(1, '05d')
-    # print test
 
     print ("---------------------------------------------------------------")
     print ("renum_atoms:")
@@ -98,6 +82,7 @@ def renum_atoms(filename,folder):
 
             # we chop up the line, cutting out the current atom number and putting the value of counter as atom number
             line=line[:6]+format(counter, '05d')+line[11:]
+            
             # write it to temp file and increase counter
             tempfile.write(line)
             counter=counter+1
@@ -108,4 +93,4 @@ def renum_atoms(filename,folder):
 
     # finally, we replace the original file with the temporary one
     os.system("rm "+filename)
-    os.system("mv "+folder+"/tmp.pdb "+filename)
+    os.system("mv tmp.pdb "+filename)

--- a/runfirst.py
+++ b/runfirst.py
@@ -33,7 +33,7 @@ def firstsim(exec_folder,cleanpdb):
 
     # if the output file is already here we don't need to do anything
     if (os.path.isfile(cleanpdb[:-9] + "hydro.pdb")):
-        print("hydro file already generated: " + os.path.basename(cleanpdb[:-9] + "hydro.pdb"))
+        print("   hydro file already generated: " + os.path.basename(cleanpdb[:-9] + "hydro.pdb"))
         return cleanpdb[:-9] + "hydro.pdb"
 
     # remove any files outputted by this script (in case it was cancelled midway-through before)

--- a/runfirst.py
+++ b/runfirst.py
@@ -36,11 +36,14 @@ def firstsim(exec_folder,cleanpdb):
         print("hydro file already generated: " + os.path.basename(cleanpdb[:-9] + "hydro.pdb"))
         return cleanpdb[:-9] + "hydro.pdb"
 
+    # remove any files outputted by this script (in case it was cancelled midway-through before)
+    os.system("rm -f *temp* *.out *list *map*")
+
     # add hydrogens
-    os.system(exec_folder+"/reduce.3.23.130521 -DB "+exec_folder+"/reduce_het_dict.txt -build "+cleanpdb+" > "+cleanpdb[:-9]+"hydro_incomplete.pdb")
+    os.system(exec_folder+"/reduce.3.23.130521 -DB "+exec_folder+"/reduce_het_dict.txt -build "+cleanpdb+" > "+cleanpdb[:-9]+"hydro_temp.pdb")
 
     # now, we call an external function to renumber the atoms taking the hydrogens into account
-    renum_atoms(cleanpdb[:-9]+"hydro_incomplete.pdb")
+    renum_atoms(cleanpdb[:-9]+"hydro_temp.pdb")
 
     # finally we run FIRST with the PDB after hydrogen addition!
 
@@ -48,12 +51,12 @@ def firstsim(exec_folder,cleanpdb):
     print ("firstsim: running FIRST with new PDB file after hydrogens added")
     print ("----------------------------------------------------------------")
 
-    os.system(exec_folder+"/FIRST-190916-SAW/src/FIRST "+cleanpdb[:-9]+"hydro_incomplete.pdb -non -dil 1 -E -0 -covout -hbout -phout -srout -L "+exec_folder+"/FIRST-190916-SAW")
+    os.system(exec_folder+"/FIRST-190916-SAW/src/FIRST "+cleanpdb[:-9]+"hydro_temp.pdb -non -dil 1 -E -0 -covout -hbout -phout -srout -L "+exec_folder+"/FIRST-190916-SAW")
 
-    # rename the file to indicate it is complete
-    os.system("mv " + cleanpdb[:-9] + "hydro_incomplete.pdb " + cleanpdb[:-9] + "hydro.pdb")
+    # rename the file to indicate it is complete (remove i[ncomplete])
+    os.system("mv " + cleanpdb[:-9] + "hydro_temp.pdb " + cleanpdb[:-9] + "hydro.pdb")
 
-    # finally, return the hydro-added PDB path
+    # finally, return the hydro-added PDB path
     return cleanpdb[:-9]+"hydro.pdb"
 
 

--- a/runfirst.py
+++ b/runfirst.py
@@ -13,7 +13,6 @@ firstsim - main function for running FIRST analysis on a protein
 
 Inputs:
 - string exec_folder: folder where the python scripts are located (full path)
-- struct args: structure containing all arguments already parsed
 - string cleanpdb: full path to PDB file after cleaning (by extension, also includes path to where all outputs are)
 
 Outputs:
@@ -22,7 +21,7 @@ Outputs:
 '''
 
 
-def firstsim(exec_folder,args,cleanpdb):
+def firstsim(exec_folder,cleanpdb):
 
     print ("---------------------------------------------------------------")
     print ("firstsim:")
@@ -82,7 +81,7 @@ def renum_atoms(filename):
 
             # we chop up the line, cutting out the current atom number and putting the value of counter as atom number
             line=line[:6]+format(counter, '05d')+line[11:]
-            
+
             # write it to temp file and increase counter
             tempfile.write(line)
             counter=counter+1

--- a/runfirst.py
+++ b/runfirst.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-
 '''
 runfirst.py - functions to run FIRST simulations, analyzing rigidity in proteins
+
 '''
 
 
@@ -19,8 +19,6 @@ Outputs:
 - string hydropdb: full path to PDB file after addition of hydrogens 
 
 '''
-
-
 def firstsim(exec_folder,cleanpdb):
 
     print ("---------------------------------------------------------------")
@@ -51,6 +49,7 @@ def firstsim(exec_folder,cleanpdb):
     return cleanpdb[:-9]+"hydro.pdb"
 
 
+
 '''
 renum_atoms: renumber the atoms in a PDB file to make sure they're in order and without gaps
 
@@ -58,8 +57,6 @@ Inputs:
 string filename: path to origin PDB file
 
 '''
-
-
 def renum_atoms(filename):
 
     # open the input file and a temp file

--- a/runfroda.py
+++ b/runfroda.py
@@ -112,7 +112,7 @@ def frodasim(exec_folder,args,hydro_file):
                     pass
 
                 # now there's some setup before starting FRODA: we need to copy the correct mode file from Modes...
-                os.system("cp "+folder+"/Modes/"+"mode"+mode+".in "+folder+"/Runs/"+str(cut)+"/Mode"+mode+"-"+sign+"/mode.in")
+                os.system("cp "+folder+"/mode"+mode+".in "+folder+"/Runs/"+str(cut)+"/Mode"+mode+"-"+sign+"/mode.in")
                 # ... the relevant PDB_file, and cov.out, and hbonds.out, and hphobes.out as input files (also we need to create an empty stacked.in)
                 os.system("cp "+hydro_file+" "+folder+"/Runs/"+str(cut)+"/Mode"+mode+"-"+sign+"/tmp.pdb")
                 os.system("touch "+folder+"/Runs/"+str(cut)+"/Mode"+mode+"-"+sign+"/stacked.in")

--- a/runfroda.py
+++ b/runfroda.py
@@ -1,6 +1,8 @@
 '''
 runfroda.py - functions to run FRODA_simulations, generating conformers for the proteins
+
 '''
+
 
 import os
 from multiprocessing import Pool
@@ -11,13 +13,14 @@ call_command: simple wrapper for calling shell commands
 
 Inputs: 
 - string command: shell command to be run
-'''
 
+'''
 def call_command(command):
     print ("--- calling:" + command)
     os.system(command)
     print ("--- finished calling:" + command)
     return
+
 
 
 '''
@@ -29,7 +32,6 @@ Inputs:
 - string hydro_file: full path to PDB file after addition of hydrogens (by extension, also includes path to where all outputs are)
 
 '''
-
 def frodasim(exec_folder,args,hydro_file):
 
     print ("---------------------------------------------------------------")
@@ -74,9 +76,6 @@ def frodasim(exec_folder,args,hydro_file):
     print ("---------------------------------------------------------------")
     print ("runfroda: preparing folders for FRODA")
     print ("----------------------------------------------------------------")
-
-    # we isolate the name of the protein, which is in the PDB_path somewhere!
-    prot=hydro_file.rsplit("/",1)[1][:-10]
 
     # now we make modelist into a list of strings instead of ints and define the signs positive and negative
     modelist=[format(i, '02d') for i in modelist]

--- a/runfroda.py
+++ b/runfroda.py
@@ -110,6 +110,7 @@ def frodasim(exec_folder,args,hydro_file):
                 if (confs_file and freq_file):
                     if (int(confs_file[0][5:]) >= totconf):
                         if (freq % int(freq_file[0][4:]) == 0):
+                            print("   conformers already generated for " + str(cut) + "-mode" + mode + "-" + sign)
                             os.chdir("..")
                             continue
 

--- a/runfroda.py
+++ b/runfroda.py
@@ -82,8 +82,13 @@ def frodasim(exec_folder,args,hydro_file):
     base = os.getcwd()
 
     # folder for all the conformers and other outputs
-    os.system("mkdir -p Runs_step" + str(step) + "_dstep" + str(dstep))
-    os.chdir("Runs_step" + str(step) + "_dstep" + str(dstep))
+    dir = "Runs"
+    if (step != 0.1):
+        dir += "_step" + str(step)
+    if (dstep != 0.01):
+        dir += "_dstep" + str(dstep)
+    os.system("mkdir -p " + dir)
+    os.chdir(dir)
 
     # create a list of commands, that will later be given to a pool of processes to run
     commands = []

--- a/runfroda.py
+++ b/runfroda.py
@@ -83,6 +83,8 @@ def frodasim(exec_folder,args,hydro_file):
 
     # folder for all the conformers and other outputs
     dir = "Runs"
+    if (not args.multiple):
+        dir += "_single-chain"
     if (step != 0.1):
         dir += "_step" + str(step)
     if (dstep != 0.01):

--- a/scripts/SLURM-run_pdb2movies.sh
+++ b/scripts/SLURM-run_pdb2movies.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+dir=$1
+pdbs=$2
+options=$3
+
+for pdb in $pdbs
+do
+
+jobfile=`printf "$pdb.sh"`
+
+cat > ${jobfile} << EOD
+#!/bin/bash
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem-per-cpu=2012
+#SBATCH --time=48:00:00
+
+python3 ../pdb2movie.py $dir$pdb $options
+
+EOD
+
+(sbatch -q taskfarm ${jobfile})
+
+done


### PR DESCRIPTION
When about to generate some new output, the program now first checks if it has already been generated by a previous run and if so skips to the next section. Benefits of this include:
-if the program dies/is killed, calling it exactly the way it was before should make it pick up (more or less) where it left off
-whenever new options are used on a previously-used pdb, a lot of preprocessing is reused
-generating videos with alternative views, fps, resolutions, or combi-ness to those already generated now only requires some frame generation, not any simulations
-the above is all done automatically, with no user input necessary; thus multiple scripts to perform specific parts of the process are no-longer needed

More than one --video view/configuration file can now be given

Outputs videos are now uniquely defined based on input arguments so will no longer collide

--overwrite and --forceoverwrite options added. The latter deletes anything in the output folder before beginning; the former does too, but with an are-you-sure warning first

Other miscellaneous performance enhancements, cleanups, bugfixes, and QoL improvements (see individual commits for more detail)